### PR TITLE
Add support for control datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ data
 ```
 Place your .PAR/.REC MRI data in the 'data' directory under the appropriate data folder. p-Brain will create subdirectories within the data folders (data_1, data_2 etc.) automatically. The names of the data folders are irrelevant, but listed above as data_1 and data_2 for clarity.  Further, analysis images will be placed in the Images subfolder, and the NIfTI files will be placed in the subfolder of the same name.
 
+If you would like to analyse control datasets, add a folder named `controls` inside
+the `data` directory and place the control subfolders there (for example
+`data/controls/log1`). Setting the `CONTROLS` flag to `True` in
+`utils/settings.py` enables this behaviour. When a control dataset is processed,
+p-Brain will automatically create a `control.json` file inside the respective
+control directory to mark it as such.
+
 NIfTI files can also be used directly by simply creating a folder of the same name and placing the .nii files therein. This will avoid the automatic conversion from .PAR/.REC to .nii/.json. 
 
 There are several files that are important to the analysis, I will list the variables below, which can be changed in the parameters.py file to fit your naming scheme: 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,7 +1,12 @@
 import os
 import sys
+import json
 import matplotlib
 matplotlib.use("TkAgg")
+
+# Global toggle for analysing control data
+CONTROLS = False
+CONTROL_FLAG_FILENAME = "control.json"
 
 def create_directory(path):
     if not os.path.exists(path):
@@ -10,6 +15,16 @@ def create_directory(path):
 def setup_directories(log_number):
     base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
     data_directory = os.path.join(base_path, 'Data', log_number)
+
+    # Look for control data if enabled
+    if CONTROLS:
+        control_directory = os.path.join(base_path, 'Data', 'controls', log_number)
+        if os.path.isdir(control_directory):
+            data_directory = control_directory
+            flag_path = os.path.join(control_directory, CONTROL_FLAG_FILENAME)
+            if not os.path.exists(flag_path):
+                with open(flag_path, 'w') as f:
+                    json.dump({"control": True, "id": log_number}, f, indent=4)
     analysis_directory = os.path.join(data_directory, 'Analysis')
     nifti_directory = os.path.join(data_directory, 'NIfTI')
     image_directory = os.path.join(data_directory, 'Images')


### PR DESCRIPTION
## Summary
- implement global CONTROLS switch and control flag creation
- document control dataset behaviour in README

## Testing
- `python3 -m py_compile main.py utils/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68404eb31e9c8321bb7873f03349b0bf