### PR TITLE
Support control subfolder in enumerator

### DIFF
--- a/enumerator.py
+++ b/enumerator.py
@@ -2,7 +2,7 @@ import sys
 import subprocess
 import os
 
-# Path to the directory containing subfolders
+# Path to the directory containing the datasets
 data_directory = "/Users/edt/Desktop/p-brain/data"
 
 # Get arguments from the command line
@@ -10,8 +10,23 @@ args = sys.argv[1:]
 
 # Check if '--all' is specified
 if "--all" in args:
-    # Get all subfolder names in alphanumeric order
-    ids = sorted(name for name in os.listdir(data_directory) if os.path.isdir(os.path.join(data_directory, name)))
+    # Collect subfolder names in alphanumeric order
+    ids = []
+    for name in sorted(os.listdir(data_directory)):
+        full_path = os.path.join(data_directory, name)
+        if not os.path.isdir(full_path):
+            continue
+
+        lower_name = name.lower()
+
+        # If a control directory is found, enumerate over its subfolders
+        if lower_name in {"control", "controls"}:
+            for ctrl in sorted(os.listdir(full_path)):
+                ctrl_path = os.path.join(full_path, ctrl)
+                if os.path.isdir(ctrl_path):
+                    ids.append(ctrl)
+        else:
+            ids.append(name)
 else:
     # Otherwise, use the supplied IDs
     ids = args


### PR DESCRIPTION
## Summary
- allow enumerator to include `control` subfolder contents when enumerating IDs

## Testing
- `python3 -m py_compile enumerator.py`

------
https://chatgpt.com/codex/tasks/task_e_68405455302083219fa798e7f4826544