### PR TITLE
Add controls option in enumerator

### DIFF
--- a/enumerator.py
+++ b/enumerator.py
@@ -3,13 +3,16 @@ import subprocess
 import os
 
 # Path to the directory containing the datasets
-data_directory = "/Users/edt/Desktop/p-brain/data"
+data_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
 # Get arguments from the command line
 args = sys.argv[1:]
 
+# Normalize args for easy checks
+args_lower = [arg.lower() for arg in args]
+
 # Check if '--all' is specified
-if "--all" in args:
+if "--all" in args_lower:
     # Collect subfolder names in alphanumeric order
     ids = []
     for name in sorted(os.listdir(data_directory)):
@@ -27,9 +30,22 @@ if "--all" in args:
                     ids.append(ctrl)
         else:
             ids.append(name)
+elif "--controls" in args_lower:
+    # Only enumerate over the control datasets
+    ids = []
+    for name in sorted(os.listdir(data_directory)):
+        full_path = os.path.join(data_directory, name)
+        if not os.path.isdir(full_path):
+            continue
+        if name.lower() in {"control", "controls"}:
+            for ctrl in sorted(os.listdir(full_path)):
+                ctrl_path = os.path.join(full_path, ctrl)
+                if os.path.isdir(ctrl_path):
+                    ids.append(ctrl)
+            break
 else:
     # Otherwise, use the supplied IDs
-    ids = args
+    ids = [arg for arg in args if not arg.startswith("--")]
 
 # Template for the command to run
 command_template = "python3 main.py --id {} --option 66"


### PR DESCRIPTION
## Summary
- use relative path for `data_directory`
- add `--controls` command line option to run only over control datasets

## Testing
- `python3 -m py_compile enumerator.py`
- `python3 enumerator.py --controls` *(fails: No module named 'matplotlib')*
- `python3 enumerator.py --all | head` *(fails: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_6840593c92dc83219083ddf7312cdd13