### PR TITLE
Allow custom AI segmentation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ There are several files that are important to the analysis, I will list the vari
     - **axial_t2_3D_filename**: An axial reconstruction of the 3D T2 sequence above.
     - **axial_t1_3D_filename**: : An axial reconstruction of the 3D T1 sequence above.
 
-The above files can be renamed to suit different purposes/sequences which can be done globally in the utils/parameters.py file. See below for some of the most useful, especially with the _boundary_ addon: 
+The above files can be renamed to suit different purposes/sequences which can be done globally in the `utils/parameters.py` file. This file also contains a `SEGMENTATION_METHOD` setting that controls which tool is used for the automated tissue segmentation (default `fastsurfer`). See below for some of the most useful, especially with the _boundary_ addon:
 ![correlated_slices](https://github.com/edtireli/p-brain/assets/129996957/e2c952ea-25ce-431b-bedd-a3eb24e49d67)
 
 

--- a/modules/AI_input_functions.py
+++ b/modules/AI_input_functions.py
@@ -389,7 +389,7 @@ def input_function_AI(analysis_directory, nifti_directory, image_directory, file
     flair_3D_filename, axial_flair_3D_filename, axial_t2_2D_filename, dce_filename = filenames
     refresh_nifti_directory(nifti_directory)
     
-    IsVFA, IsIR, apple_metal, boundary, _ = parameters
+    IsVFA, IsIR, apple_metal, boundary, _, _ = parameters
 
     filename = os.path.join(nifti_directory, dce_filename)
     nifti_img = nib.load(filename)

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -360,35 +360,47 @@ def segmentation(
     sid,
     apple_metal=True,
     rerun=False,
+    method="fastsurfer",
 ):
-    # Check if FastSurfer is installed
-    if not os.path.exists(fastsurfer_path):
-        raise Exception("FastSurfer not found, ensure correct installation and configuration of path.")
+    method = (method or "fastsurfer").lower()
 
-    # Run FastSurfer if the segmentation file doesn't exist or rerun is forced
-    if rerun or not os.path.exists(seg_mgz_path):
-        if os.path.exists(seg_mgz_path):
-            print("Rerunning FastSurfer segmentation...")
-        else:
-            print("Segmentation file not found, running FastSurfer...")
-        if apple_metal:
-            command = (
-                f"export PYTORCH_ENABLE_MPS_FALLBACK=1 && "
-                f"{fastsurfer_path} --seg_only --device mps "
-                f"--t1 {t1_path} "
-                f"--sid {sid} "
-                f"--sd {output_dir}"
+    if method == "fastsurfer":
+        # Check if FastSurfer is installed
+        if not os.path.exists(fastsurfer_path):
+            raise Exception(
+                "FastSurfer not found, ensure correct installation and configuration of path."
             )
+
+        # Run FastSurfer if the segmentation file doesn't exist or rerun is forced
+        if rerun or not os.path.exists(seg_mgz_path):
+            if os.path.exists(seg_mgz_path):
+                print("Rerunning FastSurfer segmentation...")
+            else:
+                print("Segmentation file not found, running FastSurfer...")
+            if apple_metal:
+                command = (
+                    f"export PYTORCH_ENABLE_MPS_FALLBACK=1 && "
+                    f"{fastsurfer_path} --seg_only --device mps "
+                    f"--t1 {t1_path} "
+                    f"--sid {sid} "
+                    f"--sd {output_dir}"
+                )
+            else:
+                command = (
+                    f"{fastsurfer_path} --seg_only "
+                    f"--t1 {t1_path} "
+                    f"--sid {sid} "
+                    f"--sd {output_dir}"
+                )
+            subprocess.run(command, shell=True)
         else:
-            command = (
-                f"{fastsurfer_path} --seg_only "
-                f"--t1 {t1_path} "
-                f"--sid {sid} "
-                f"--sd {output_dir}"
-            )
-        subprocess.run(command, shell=True)
+            print("Segmentation file already exists, skipping FastSurfer segmentation.")
     else:
-        print("Segmentation file already exists, skipping FastSurfer segmentation.")
+        print(f"Segmentation method '{method}' selected. Skipping FastSurfer execution.")
+        if not os.path.exists(seg_mgz_path):
+            raise FileNotFoundError(
+                f"Segmentation file not found: {seg_mgz_path}. Provide your own segmentation before running."
+            )
 
     aseg_mgz_path = seg_mgz_path
 
@@ -1965,7 +1977,7 @@ def tissue_function_AI(analysis_directory, nifti_directory, image_directory, fil
     t1_3D_filename, axial_t1_3D_filename, t2_3D_filename, axial_t2_3D_filename, \
         flair_3D_filename, axial_flair_3D_filename, axial_t2_2D_filename, dce_filename = filenames
 
-    IsVFA, IsIR, apple_metal, boundary, RERUN_SEGMENTATION = parameters
+    IsVFA, IsIR, apple_metal, boundary, RERUN_SEGMENTATION, SEGMENTATION_METHOD = parameters
 
     fastsurfer_path = '/Users/edt/FastSurfer/run_fastsurfer.sh'
     t1_path = os.path.join(nifti_directory, t1_3D_filename)
@@ -1987,6 +1999,7 @@ def tissue_function_AI(analysis_directory, nifti_directory, image_directory, fil
         sid,
         apple_metal,
         RERUN_SEGMENTATION,
+        SEGMENTATION_METHOD,
     )
 
     # Paths to masks in the same directory as aparc.DKTatlas+aseg.deep.mgz

--- a/modules/opt01_T1_fit.py
+++ b/modules/opt01_T1_fit.py
@@ -219,7 +219,7 @@ def plot_brain_slices_grid(M0_matrix, T1_matrix, image_directory):
         close_plot_after_delay(3, fig)
         plt.show()
 def T1_fit(data_directory, analysis_directory, nifti_directory, image_directory, filenames, parameters):
-    _, IsVFA, IsIR, _, _ = parameters
+    _, IsVFA, IsIR, _, _, _ = parameters
     t1_3D_filename, axial_t1_3D_filename, t2_3D_filename, axial_t2_3D_filename, \
     flair_3D_filename, axial_flair_3D_filename, axial_t2_2D_filename, dce_filename = filenames
     

--- a/modules/opt02_input_functions.py
+++ b/modules/opt02_input_functions.py
@@ -215,7 +215,7 @@ def input_function(analysis_directory, nifti_directory, image_directory, filenam
         flair_3D_filename, axial_flair_3D_filename, axial_t2_2D_filename, dce_filename = filenames
     refresh_nifti_directory(nifti_directory)
     
-    IsVFA, IsIR, _, _, _ = parameters
+    IsVFA, IsIR, _, _, _, _ = parameters
     filename = os.path.join(nifti_directory, dce_filename)
     nifti_img = nib.load(filename)
     TR = nifti_img.header.get_zooms()[-1] #*1e3

--- a/utils/parameters.py
+++ b/utils/parameters.py
@@ -20,7 +20,15 @@ def global_parameters():
     apple_metal = True # Enable if running on apple M1/M2/M3...
     boundary = True #compute boundary mask from GM/WM masks and plot/compute patlak values alongside wm/gm
     RERUN_SEGMENTATION = False  # Force rerun of FastSurfer segmentation
-    return (IsVFA, IsIR, apple_metal, boundary, RERUN_SEGMENTATION)
+    SEGMENTATION_METHOD = "fastsurfer"  # Choose segmentation tool (default FastSurfer)
+    return (
+        IsVFA,
+        IsIR,
+        apple_metal,
+        boundary,
+        RERUN_SEGMENTATION,
+        SEGMENTATION_METHOD,
+    )
 
 def refresh_nifti_directory(nifti_directory):
     return os.listdir(nifti_directory)


### PR DESCRIPTION
## Summary
- expose `SEGMENTATION_METHOD` in `global_parameters`
- adjust AI tissue functions to pass the chosen segmentation method
- support skipping FastSurfer and using external segmentations
- update modules to handle the new parameter tuple
- document the new setting in the README

## Testing
- `python3 -m py_compile utils/parameters.py modules/AI_input_functions.py modules/opt02_input_functions.py modules/opt01_T1_fit.py modules/AI_tissue_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_684059a987b88321a085258c1a339230