### PR TITLE
Make ROI AI models configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,16 @@ The idea is to use the options in chronological order, as each step requires the
 
 ## 6. Fully Automated Mode
 From v2.0.0 onwards, a new fully automated implementation is available within which 4 neural networks were trained on carotid artery and sinus sagitalis vein identification and ROI drawing. Further a fast AI segmentation tool, FastSurfer, is also implemented and segments the brain within few minutes. Our pipeline now integrates both AI utilities to conduct the entire analysis automatically: T1/M0 fit, vein/artery ROI drawing, tissue segmentation/ROIs and the final Patlak analysis of the determination of Ki (BBB permeability, slice by slice and voxelwise) as well as a CBF map (using a 2-compartment model) and a Ki map, as well as a whole-volume Ki calculation. The image below shows an example of the results of one such automated result (slice-by-slice Ki determination)
+
 ![AI_Tissue_slice_5_segmented_median](https://github.com/user-attachments/assets/328c1a43-294d-42fa-bad5-518bd1af8439)
+
+### Custom AI model paths
+The four neural networks used for Right Internal Carotid Artery (RICA) and sinus
+ sagittalis segmentation can be replaced with your own models. The default
+ locations are defined in `utils/settings.py` under `AI_MODEL_PATHS`. Set these
+ paths or provide the environment variables `SLICE_CLASSIFIER_RICA_MODEL`,
+ `RICA_ROI_MODEL`, `SLICE_CLASSIFIER_SS_MODEL` and `SS_ROI_MODEL` to override the
+ defaults.
 
 ## 7. Contributions
 For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 

--- a/modules/AI_input_functions.py
+++ b/modules/AI_input_functions.py
@@ -10,6 +10,7 @@ from utils.mapping import *
 from utils.plotting import *
 from utils.loading import *
 from matplotlib.path import Path
+from utils.settings import AI_MODEL_PATHS
 import glob
 import json
 import time
@@ -308,10 +309,18 @@ def plot_relevant_slices_with_rois(original_slices, relevant_slices, relevant_ro
 def run_ai_roi_extraction(filename, analysis_dir, image_dir, nifti_dir, time, IsVFA=False, filenames='filenames'):
     print(colored('Starting AI-based ROI extraction...', 'green'))
 
-    slice_classifier_rica = load_model('AI/slice_classifier_model_rica.keras', compile=False)
-    rica_roi_model = load_model('AI/rica_roi_model.keras', compile=False)
-    slice_classifier_ss = load_model('AI/ss_slice_classifier.keras', compile=False)
-    ss_roi_model = load_model('AI/ss_roi_model.keras', compile=False)
+    slice_classifier_rica = load_model(
+        AI_MODEL_PATHS['slice_classifier_rica'], compile=False
+    )
+    rica_roi_model = load_model(
+        AI_MODEL_PATHS['rica_roi'], compile=False
+    )
+    slice_classifier_ss = load_model(
+        AI_MODEL_PATHS['slice_classifier_ss'], compile=False
+    )
+    ss_roi_model = load_model(
+        AI_MODEL_PATHS['ss_roi'], compile=False
+    )
 
     rotated_data, mri_data = preprocess_data(filename)
 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -8,6 +8,23 @@ matplotlib.use("TkAgg")
 CONTROLS = False
 CONTROL_FLAG_FILENAME = "control.json"
 
+# Paths to the neural network models used for artery and vein ROI extraction.
+# These can be overridden by environment variables to use custom models.
+AI_MODEL_PATHS = {
+    'slice_classifier_rica': os.environ.get(
+        'SLICE_CLASSIFIER_RICA_MODEL', 'AI/slice_classifier_model_rica.keras'
+    ),
+    'rica_roi': os.environ.get(
+        'RICA_ROI_MODEL', 'AI/rica_roi_model.keras'
+    ),
+    'slice_classifier_ss': os.environ.get(
+        'SLICE_CLASSIFIER_SS_MODEL', 'AI/ss_slice_classifier.keras'
+    ),
+    'ss_roi': os.environ.get(
+        'SS_ROI_MODEL', 'AI/ss_roi_model.keras'
+    ),
+}
+
 def create_directory(path):
     if not os.path.exists(path):
         os.makedirs(path)


### PR DESCRIPTION
## Summary
- allow overriding artery/vein ROI AI model paths via `AI_MODEL_PATHS` in settings
- use `AI_MODEL_PATHS` when loading models
- document custom AI model configuration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68405a58757c83219226a72e5a20d604