### PR TITLE
Fix enumerator control handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,12 @@ Place your .PAR/.REC MRI data in the `data` directory under any folder name of y
 If you would like to analyse control datasets, add a folder named `controls` inside
 the `data` directory and place the control subfolders there (for example
 `data/controls/log1`). Setting the `CONTROLS` flag to `True` in
-`utils/settings.py` enables this behaviour. When a control dataset is processed,
-p-Brain will automatically create a `control.json` file inside the respective
-control directory to mark it as such.
+`utils/settings.py` or exporting the environment variable
+`PBRAIN_CONTROLS=1` enables this behaviour. The `enumerator.py` script
+automatically sets this variable when invoked with `--controls`. When a
+control dataset is processed, p-Brain will automatically create a
+`control.json` file inside the respective control directory to mark it as
+such.
 
 NIfTI files can also be used directly by simply creating a folder of the same name and placing the .nii files therein. This will avoid the automatic conversion from .PAR/.REC to .nii/.json. 
 

--- a/enumerator.py
+++ b/enumerator.py
@@ -11,10 +11,11 @@ args = sys.argv[1:]
 # Normalize args for easy checks
 args_lower = [arg.lower() for arg in args]
 
-# Check if '--all' is specified
+# Determine which datasets to process and whether they are controls
+datasets = []  # list of tuples (id, is_control)
+
 if "--all" in args_lower:
     # Collect subfolder names in alphanumeric order
-    ids = []
     for name in sorted(os.listdir(data_directory)):
         full_path = os.path.join(data_directory, name)
         if not os.path.isdir(full_path):
@@ -27,12 +28,11 @@ if "--all" in args_lower:
             for ctrl in sorted(os.listdir(full_path)):
                 ctrl_path = os.path.join(full_path, ctrl)
                 if os.path.isdir(ctrl_path):
-                    ids.append(ctrl)
+                    datasets.append((ctrl, True))
         else:
-            ids.append(name)
+            datasets.append((name, False))
 elif "--controls" in args_lower:
     # Only enumerate over the control datasets
-    ids = []
     for name in sorted(os.listdir(data_directory)):
         full_path = os.path.join(data_directory, name)
         if not os.path.isdir(full_path):
@@ -41,17 +41,27 @@ elif "--controls" in args_lower:
             for ctrl in sorted(os.listdir(full_path)):
                 ctrl_path = os.path.join(full_path, ctrl)
                 if os.path.isdir(ctrl_path):
-                    ids.append(ctrl)
+                    datasets.append((ctrl, True))
             break
 else:
     # Otherwise, use the supplied IDs
-    ids = [arg for arg in args if not arg.startswith("--")]
+    for arg in args:
+        if arg.startswith("--"):
+            continue
+        ctrl_path = os.path.join(data_directory, "controls", arg)
+        is_ctrl = os.path.isdir(ctrl_path)
+        datasets.append((arg, is_ctrl))
 
 # Template for the command to run
 command_template = "python3 main.py --id {} --option 66"
 
-# Iterate through IDs and execute the command
-for id in ids:
+# Iterate through datasets and execute the command
+for id, is_control in datasets:
     command = command_template.format(id)
-    print(f"Running: {command}")
-    subprocess.run(command, shell=True)
+    env = os.environ.copy()
+    if is_control:
+        env["PBRAIN_CONTROLS"] = "true"
+    else:
+        env.pop("PBRAIN_CONTROLS", None)
+    print(f"Running: {command} (control={is_control})")
+    subprocess.run(command, shell=True, env=env)

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -4,8 +4,10 @@ import json
 import matplotlib
 matplotlib.use("TkAgg")
 
-# Global toggle for analysing control data
-CONTROLS = False
+# Global toggle for analysing control data. The flag can also be
+# overridden by setting the environment variable ``PBRAIN_CONTROLS`` to
+# ``1``/``true``.
+CONTROLS = os.environ.get("PBRAIN_CONTROLS", "False").lower() in ("1", "true", "yes")
 CONTROL_FLAG_FILENAME = "control.json"
 
 # Paths to the neural network models used for artery and vein ROI extraction.


### PR DESCRIPTION
## Summary
- allow `CONTROLS` setting to be toggled through `PBRAIN_CONTROLS` env var
- make `enumerator.py` pass the env var when running control datasets
- document new behaviour in README

## Testing
- `python3 -m py_compile enumerator.py utils/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_68405cfa6fa88321a5d399a7720b3dce