### PR TITLE
Allow Keras models via LFS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+AI/*.keras filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 data/*
 AI/*
 !data/.gitkeep
+!AI/*.keras
 !AI/.gitkeep
 


### PR DESCRIPTION
## Summary
- track `.keras` models in the AI directory with Git LFS
- update `.gitignore` to allow those files

## Testing
- `git lfs version`

------
https://chatgpt.com/codex/tasks/task_e_684bd72f54d083218959e3fc99941702