### PR TITLE
Add selectable kinetic model

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,12 @@ Pre-trained models are available at
 [Zenodo](https://doi.org/10.5281/zenodo.15655347). Download and extract them
 into the `AI/` directory so the default paths resolve.
 
+### Kinetic model selection
+The permeability analysis defaults to Patlak modelling. Set the variable
+`KINETIC_MODEL` in `utils/settings.py` or export the environment variable
+`P_BRAIN_MODEL` to `two_compartment` to use the extended Tofts
+two-compartment fit instead.
+
 ## 7. Contributions
 For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 
 

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -18,10 +18,11 @@ import subprocess
 import os
 import multiprocessing
 import shutil
-from utils.settings import MULTIPROCESSING, NUMBER_OF_CORES
+from utils.settings import MULTIPROCESSING, NUMBER_OF_CORES, KINETIC_MODEL
 from utils.fonts import *
 from utils.loading import *
 from utils.plotting import *
+from .kinetic_models import two_compartment_fit
 from skimage.transform import resize
 import json
 from scipy.ndimage import binary_dilation
@@ -1659,28 +1660,26 @@ def compute_and_plot_ctcs_median(
         else:
             C_t_boundary = np.array([])
 
-        # Perform Patlak analysis for each tissue type
-        def perform_patlak(C_t):
-            if C_t.size > 0:
-                Ki, lam, SD_Ki, x_patlak, y_patlak, included = patlak_analysis_plotting(C_t, C_a_slice, time_points)
+        # Perform kinetic model fit for each tissue type
+        def perform_model_fit(C_t):
+            if C_t.size == 0:
+                return (np.nan, np.nan, np.nan, np.array([]), np.array([]), np.array([], dtype=bool))
+            if KINETIC_MODEL.lower() == 'two_compartment':
+                Ki, lam, SD_Ki = two_compartment_fit(C_a_slice, C_t, time_points)
+                return Ki, lam, SD_Ki, np.array([]), np.array([]), np.array([], dtype=bool)
             else:
-                Ki = np.nan
-                lam = np.nan
-                SD_Ki = np.nan
-                x_patlak = np.array([])
-                y_patlak = np.array([])
-                included = np.array([], dtype=bool)
-            return Ki, lam, SD_Ki, x_patlak, y_patlak, included
+                Ki, lam, SD_Ki, x_patlak, y_patlak, included = patlak_analysis_plotting(C_t, C_a_slice, time_points)
+                return Ki, lam, SD_Ki, x_patlak, y_patlak, included
 
-        Ki_wm, lambda_wm, SD_Ki_wm, x_patlak_wm, y_patlak_wm, included_wm = perform_patlak(C_t_wm)
-        Ki_cortical_gm, lambda_cortical_gm, SD_Ki_cortical_gm, x_patlak_cortical_gm, y_patlak_cortical_gm, included_cortical_gm = perform_patlak(C_t_cortical_gm)
-        Ki_subcortical_gm, lambda_subcortical_gm, SD_Ki_subcortical_gm, x_patlak_subcortical_gm, y_patlak_subcortical_gm, included_subcortical_gm = perform_patlak(C_t_subcortical_gm)
-        Ki_gm_brainstem, lambda_gm_brainstem, SD_Ki_gm_brainstem, x_patlak_gm_brainstem, y_patlak_gm_brainstem, included_gm_brainstem = perform_patlak(C_t_gm_brainstem)
-        Ki_gm_cerebellum, lambda_gm_cerebellum, SD_Ki_gm_cerebellum, x_patlak_gm_cerebellum, y_patlak_gm_cerebellum, included_gm_cerebellum = perform_patlak(C_t_gm_cerebellum)
-        Ki_wm_cerebellum, lambda_wm_cerebellum, SD_Ki_wm_cerebellum, x_patlak_wm_cerebellum, y_patlak_wm_cerebellum, included_wm_cerebellum = perform_patlak(C_t_wm_cerebellum)
-        Ki_wm_cc, lambda_wm_cc, SD_Ki_wm_cc, x_patlak_wm_cc, y_patlak_wm_cc, included_wm_cc = perform_patlak(C_t_wm_cc)
+        Ki_wm, lambda_wm, SD_Ki_wm, x_patlak_wm, y_patlak_wm, included_wm = perform_model_fit(C_t_wm)
+        Ki_cortical_gm, lambda_cortical_gm, SD_Ki_cortical_gm, x_patlak_cortical_gm, y_patlak_cortical_gm, included_cortical_gm = perform_model_fit(C_t_cortical_gm)
+        Ki_subcortical_gm, lambda_subcortical_gm, SD_Ki_subcortical_gm, x_patlak_subcortical_gm, y_patlak_subcortical_gm, included_subcortical_gm = perform_model_fit(C_t_subcortical_gm)
+        Ki_gm_brainstem, lambda_gm_brainstem, SD_Ki_gm_brainstem, x_patlak_gm_brainstem, y_patlak_gm_brainstem, included_gm_brainstem = perform_model_fit(C_t_gm_brainstem)
+        Ki_gm_cerebellum, lambda_gm_cerebellum, SD_Ki_gm_cerebellum, x_patlak_gm_cerebellum, y_patlak_gm_cerebellum, included_gm_cerebellum = perform_model_fit(C_t_gm_cerebellum)
+        Ki_wm_cerebellum, lambda_wm_cerebellum, SD_Ki_wm_cerebellum, x_patlak_wm_cerebellum, y_patlak_wm_cerebellum, included_wm_cerebellum = perform_model_fit(C_t_wm_cerebellum)
+        Ki_wm_cc, lambda_wm_cc, SD_Ki_wm_cc, x_patlak_wm_cc, y_patlak_wm_cc, included_wm_cc = perform_model_fit(C_t_wm_cc)
         if boundary and C_t_boundary.size > 0:
-            Ki_boundary, lambda_boundary, SD_Ki_boundary, x_patlak_boundary, y_patlak_boundary, included_boundary = perform_patlak(C_t_boundary)
+            Ki_boundary, lambda_boundary, SD_Ki_boundary, x_patlak_boundary, y_patlak_boundary, included_boundary = perform_model_fit(C_t_boundary)
         else:
             Ki_boundary = np.nan
             lambda_boundary = np.nan
@@ -2029,9 +2028,12 @@ def compute_and_plot_ctcs_median(
     # -----------------------------------------------------------------------------
     def patlak_total(C_t):
         if not C_t.size:
-            return np.nan, np.nan, np.nan      # Ki, λ, SD_Ki
+            return np.nan, np.nan, np.nan
+        if KINETIC_MODEL.lower() == 'two_compartment':
+            Ki, lam, SD = two_compartment_fit(C_a_total, C_t, time_points_total)
+            return Ki, lam, SD
         if correct_signal_jumps:
-            _, bad, _ = mask_problematic(C_t)  # same length as C_t
+            _, bad, _ = mask_problematic(C_t)
         else:
             bad = None
         Ki, lam, SD, *_ = patlak_with_exclusions(C_t, C_a_total, time_points_total, bad_mask=bad)

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -19,6 +19,7 @@ from .opt01_T1_fit import * # option 1
 from .opt02_input_functions import * # option 2
 from utils.mapping import *
 from utils.plotting import *
+from .kinetic_models import *
 from .opt03_time_shifting import * # option 3
 from .opt04_tissue_function import * # option 4
 from .opt05_BBB_parameters import * # option 5

--- a/modules/kinetic_models.py
+++ b/modules/kinetic_models.py
@@ -1,0 +1,35 @@
+import numpy as np
+from scipy.optimize import curve_fit
+
+
+def extended_tofts_model(t, Ktrans, ve, vp, Cp):
+    """Basic extended Tofts implementation used for the two-compartment model."""
+    integrand = np.zeros_like(t)
+    for i in range(len(t)):
+        min_len = min(len(Cp[:i+1]), len(t[:i+1]))
+        integral = np.trapz(Cp[:min_len] * np.exp(-(t[i] - t[:min_len]) * Ktrans / ve), x=t[:min_len])
+        integrand[i] = integral
+    min_len = min(len(integrand), len(Cp))
+    return Ktrans * integrand[:min_len] + vp * Cp[:min_len]
+
+
+def two_compartment_fit(c_input, c_tissue, time_array):
+    """Fit the extended Tofts two-compartment model and return Ki and lambda."""
+    if c_input.shape[0] != c_tissue.shape[0]:
+        raise ValueError("The number of time points in c_input and c_tissue must be the same.")
+
+    initial_guess = [0.5/6000, 0.2, 0.05]
+    popt, pcov = curve_fit(
+        lambda t, Ktrans, ve, vp: extended_tofts_model(t, Ktrans, ve, vp, c_input),
+        time_array,
+        c_tissue,
+        p0=initial_guess,
+    )
+
+    Ktrans_fitted, ve_fitted, vp_fitted = popt
+    std_dev_Ktrans = np.sqrt(np.diag(pcov))[0]
+
+    Ki = Ktrans_fitted * 6000
+    Ki_std = std_dev_Ktrans * 6000
+    lambda_val = ve_fitted * 100
+    return Ki, lambda_val, Ki_std

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -1,6 +1,8 @@
 from utils.plotting import *
 from utils.mapping import *
 from utils.loading import *
+from utils.settings import KINETIC_MODEL
+from .kinetic_models import two_compartment_fit
 from scipy.optimize import curve_fit
 from termcolor import colored
 
@@ -167,12 +169,17 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
     C_t = C_t[0:len(C_a)]
     time_points_s = time_points_s[0:len(C_a)]
     
-    Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
-    
-    baseline_point = find_shifted_baseline(C_t)+1
-    P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
-    print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
-    print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
+    if KINETIC_MODEL.lower() == 'two_compartment':
+        Ki, lamda, SD_Ki = two_compartment_fit(C_a, C_t, time_points_s)
+        print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
+              f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
+        P, P_std = Ki, SD_Ki
+    else:
+        Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
+        baseline_point = find_shifted_baseline(C_t)+1
+        P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
+        print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
+        print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
         
     values = [f"Ki: {Ki*6000} (+- {SD_Ki*6000})",f"lambda: {lamda*100}", f"Tissue type: {subtype_tissue} (Slice {slice_tissue})", f"Artery type: {subtype_artery} (Venous Slice {venous_slice}, Arterial Slice {arterial_slice})", f"Ki_et: {P} +- ({P_std})"]
         
@@ -192,12 +199,17 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         C_t = C_t[0:len(C_a)]
         time_points_s = time_points_s[0:len(C_a)]
         
-        Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
-        
-        baseline_point = find_shifted_baseline(C_t)+1
-        P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
-        print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
-        print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
+        if KINETIC_MODEL.lower() == 'two_compartment':
+            Ki, lamda, SD_Ki = two_compartment_fit(C_a, C_t, time_points_s)
+            print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
+                  f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
+            P, P_std = Ki, SD_Ki
+        else:
+            Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
+            baseline_point = find_shifted_baseline(C_t)+1
+            P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
+            print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
+            print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
             
         values = [f"Ki: {Ki*6000} (+- {SD_Ki*6000})",f"lambda: {lamda*100}", f"Tissue type: {subtype_tissue} (Slice {slice_tissue})", f"Artery type: {subtype_artery} (Venous Slice {venous_slice}, Arterial Slice {arterial_slice})", f"Ki_et: {P} +- ({P_std})"]
         save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue, subtype_artery, venous_slice, arterial_slice, analysis_directory)

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -15,6 +15,8 @@ MULTIPROCESSING = True
 # Default number of CPU cores used when multiprocessing is enabled
 NUMBER_OF_CORES = int(os.environ.get("P_BRAIN_CORES", 4))
 
+KINETIC_MODEL = os.environ.get("P_BRAIN_MODEL", "patlak")
+
 # Paths to the neural network models used for artery and vein ROI extraction.
 # These can be overridden by environment variables to use custom models.
 AI_MODEL_PATHS = {


### PR DESCRIPTION
## Summary
- add `KINETIC_MODEL` setting with Patlak default
- implement extended Tofts fit in `kinetic_models`
- allow BBB parameter modules to switch between Patlak and two-compartment models
- integrate switch in AI tissue analysis
- document model selection in README

## Testing
- `python -m py_compile modules/kinetic_models.py modules/opt05_BBB_parameters.py modules/AI_tissue_functions.py utils/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_685286efeaf083219d49b2a55220c350