### PR TITLE
Fix turbo mode for manual CLI use

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,11 @@
-import argparse 
+import argparse
+import os
 from utils import *
 from modules import *
+import utils.plotting as plotting
+import modules.opt01_T1_fit as opt01_T1_fit
+import modules.AI_input_functions as AI_input_functions
+import modules.AI_tissue_functions as AI_tissue_functions
 
 
 def parse_args():
@@ -12,6 +17,13 @@ def parse_args():
 
 def main():
     args = parse_args()
+
+    # Disable turbo mode when running a single CLI option so figures are shown
+    if args.option is not None and os.environ.get("PBRAIN_TURBO") != "1":
+        plotting.turbo_mode = False
+        opt01_T1_fit.turbo_mode = False
+        AI_input_functions.turbo_mode = False
+        AI_tissue_functions.turbo_mode = False
 
     if args.id:
         log_number = args.id


### PR DESCRIPTION
## Summary
- ensure CLI mode displays figures by turning off `turbo_mode`
- import modules so the flag can be set

## Testing
- `python -m py_compile main.py utils/plotting.py modules/opt01_T1_fit.py modules/AI_input_functions.py modules/AI_tissue_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_68528dad20dc8321897c43284bbbc936