### PR TITLE
Fix interactive T1 fitting visibility

### DIFF
--- a/enumerator.py
+++ b/enumerator.py
@@ -66,5 +66,8 @@ for id, is_control in datasets:
         env["PBRAIN_CONTROLS"] = "true"
     else:
         env.pop("PBRAIN_CONTROLS", None)
+    # Disable plotting and interactive windows when running in batch mode
+    # by enabling turbo mode in ``main.py``.
+    env["PBRAIN_TURBO"] = "1"
     print(f"Running: {command} (control={is_control})")
     subprocess.run(command, shell=True, env=env)

--- a/main.py
+++ b/main.py
@@ -18,8 +18,10 @@ def parse_args():
 def main():
     args = parse_args()
 
-    # Disable turbo mode when running a single CLI option so figures are shown
-    if args.option is not None and os.environ.get("PBRAIN_TURBO") != "1":
+    # Show figures when running interactively unless explicitly disabled via the
+    # ``PBRAIN_TURBO`` environment variable. The enumerator sets this variable to
+    # keep plotting off during batch processing.
+    if os.environ.get("PBRAIN_TURBO") != "1":
         plotting.turbo_mode = False
         opt01_T1_fit.turbo_mode = False
         AI_input_functions.turbo_mode = False


### PR DESCRIPTION
## Summary
- show figures by default unless PBRAIN_TURBO is explicitly set
- ensure enumerator runs in turbo mode for batch processing

## Testing
- `python -m py_compile main.py enumerator.py`

------
https://chatgpt.com/codex/tasks/task_e_68528f6cc1108321a57dc7bfe9d4a1db