### PR TITLE
Fix interactive plotting in option 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ import utils.plotting as plotting
 import modules.opt01_T1_fit as opt01_T1_fit
 import modules.AI_input_functions as AI_input_functions
 import modules.AI_tissue_functions as AI_tissue_functions
+import modules.opt03_time_shifting as opt03_time_shifting
 
 
 def parse_args():
@@ -26,6 +27,7 @@ def main():
         opt01_T1_fit.turbo_mode = False
         AI_input_functions.turbo_mode = False
         AI_tissue_functions.turbo_mode = False
+        opt03_time_shifting.turbo_mode = False
 
     if args.id:
         log_number = args.id

--- a/modules/opt03_time_shifting.py
+++ b/modules/opt03_time_shifting.py
@@ -8,6 +8,8 @@ import glob
 import json
 import time
 
+turbo_mode = True  # When True, suppress interactive plotting
+
 
 def plot_transformed_curves(shifted_vein_curve, shifted_artery_curve, slice_index, arterial_slice_index, vein_top2_peaks, time_points_s, analysis_directory, image_directory, subtype='test', scaling=1, time_shift=1):
     subtype=subtype[1]
@@ -38,8 +40,10 @@ def plot_transformed_curves(shifted_vein_curve, shifted_artery_curve, slice_inde
 
     plt.savefig(os.path.join(image_directory, 'Time Shifted Concentration Curves', subtype, f'TSCC_slice_{slice_index}_{arterial_slice_index}.png'), dpi=200)
     np.save(os.path.join(analysis_directory, 'TSCC Data', subtype, f'TSCC_slice_{slice_index}_{arterial_slice_index}.npy'), shifted_vein_curve)
-    plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()    
+    if not turbo_mode:
+        plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
+        close_plot_after_delay_plt(3)
+        plt.show()
 
 
 def get_available_arteries(analysis_directory):
@@ -209,8 +213,10 @@ def plot_transformed_curves_max(shifted_vein_curve, slice_index, artery_index, v
 
     plt.savefig(os.path.join(image_directory, 'Time Shifted Concentration Curves', 'Max', f'TSCC_slice_{slice_index}_{artery_index}.png'), dpi=200)
     np.save(os.path.join(analysis_directory, 'TSCC Data', 'Max', f'TSCC_slice_{slice_index}_{artery_index}.npy'), shifted_vein_curve)
-    plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()
+    if not turbo_mode:
+        plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
+        close_plot_after_delay_plt(3)
+        plt.show()
 
 
 


### PR DESCRIPTION
## Summary
- add turbo mode support to `opt03_time_shifting`
- disable interactive plots in option 3 when PBRAIN_TURBO=1
- register the module in `main.py` so turbo mode is respected

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68529db695b88321ae80488378fe3274