### PR TITLE
Fix interactive plotting in option 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,11 @@ import utils.plotting as plotting
 import modules.opt01_T1_fit as opt01_T1_fit
 import modules.AI_input_functions as AI_input_functions
 import modules.AI_tissue_functions as AI_tissue_functions
+import modules.opt03_time_shifting as opt03_time_shifting
+import modules.opt02_input_functions as opt02_input_functions
+import modules.opt04_tissue_function as opt04_tissue_function
+import modules.opt05_BBB_parameters as opt05_BBB_parameters
+import modules.opt00_images as opt00_images
 
 
 def parse_args():
@@ -26,6 +31,11 @@ def main():
         opt01_T1_fit.turbo_mode = False
         AI_input_functions.turbo_mode = False
         AI_tissue_functions.turbo_mode = False
+        opt03_time_shifting.turbo_mode = False
+        opt02_input_functions.turbo_mode = False
+        opt04_tissue_function.turbo_mode = False
+        opt05_BBB_parameters.turbo_mode = False
+        opt00_images.turbo_mode = False
 
     if args.id:
         log_number = args.id

--- a/modules/opt00_images.py
+++ b/modules/opt00_images.py
@@ -7,6 +7,8 @@ import numpy as np
 import matplotlib
 matplotlib.use("TkAgg")
 
+turbo_mode = True  # When True, suppress interactive plotting
+
 class MRIViewer:
     def __init__(self, nifti_directory, filenames):
         self.nifti_directory = nifti_directory
@@ -25,6 +27,9 @@ class MRIViewer:
 
 
     def display(self):
+        if turbo_mode:
+            print("[!] Turbo mode enabled; skipping image viewer.")
+            return
         t1_3D_filename, axial_t1_3D_filename, t2_3D_filename, axial_t2_3D_filename, \
         flair_3D_filename, axial_flair_3D_filename, axial_t2_2D_filename, dce_filename = self.filenames
         patterns_and_names = [
@@ -76,7 +81,11 @@ class MRIViewer:
                         # Connect to events and show the figure
                         self.fig.canvas.mpl_connect('key_press_event', self.on_key)
                         self.redraw()
-                        plt.show()
+                        if not turbo_mode:
+                            plt.show()
+                        else:
+                            plt.close(self.fig)
+                            break
 
                         # Close the GUI and break the inner loop when 'Escape' is pressed
                         if plt.get_fignums():

--- a/modules/opt02_input_functions.py
+++ b/modules/opt02_input_functions.py
@@ -5,6 +5,8 @@ from termcolor import colored
 from utils.fonts import *
 from utils.mapping import *
 from utils.plotting import *
+
+turbo_mode = True  # When True, suppress interactive plotting
 from matplotlib.path import Path
 import glob
 
@@ -24,7 +26,8 @@ class ROISelector:
         self.fig.canvas.mpl_connect('button_press_event', self.onclick)
         self.fig.canvas.mpl_connect('key_press_event', self.on_key)
         self.redraw()
-        plt.show()
+        if not turbo_mode:
+            plt.show()
 
     def onclick(self, event):
         if event.inaxes != self.ax: return

--- a/modules/opt03_time_shifting.py
+++ b/modules/opt03_time_shifting.py
@@ -8,6 +8,8 @@ import glob
 import json
 import time
 
+turbo_mode = True  # When True, suppress interactive plotting
+
 
 def plot_transformed_curves(shifted_vein_curve, shifted_artery_curve, slice_index, arterial_slice_index, vein_top2_peaks, time_points_s, analysis_directory, image_directory, subtype='test', scaling=1, time_shift=1):
     subtype=subtype[1]
@@ -38,8 +40,10 @@ def plot_transformed_curves(shifted_vein_curve, shifted_artery_curve, slice_inde
 
     plt.savefig(os.path.join(image_directory, 'Time Shifted Concentration Curves', subtype, f'TSCC_slice_{slice_index}_{arterial_slice_index}.png'), dpi=200)
     np.save(os.path.join(analysis_directory, 'TSCC Data', subtype, f'TSCC_slice_{slice_index}_{arterial_slice_index}.npy'), shifted_vein_curve)
-    plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()    
+    if not turbo_mode:
+        plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
+        close_plot_after_delay_plt(3)
+        plt.show()
 
 
 def get_available_arteries(analysis_directory):
@@ -209,8 +213,10 @@ def plot_transformed_curves_max(shifted_vein_curve, slice_index, artery_index, v
 
     plt.savefig(os.path.join(image_directory, 'Time Shifted Concentration Curves', 'Max', f'TSCC_slice_{slice_index}_{artery_index}.png'), dpi=200)
     np.save(os.path.join(analysis_directory, 'TSCC Data', 'Max', f'TSCC_slice_{slice_index}_{artery_index}.npy'), shifted_vein_curve)
-    plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()
+    if not turbo_mode:
+        plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
+        close_plot_after_delay_plt(3)
+        plt.show()
 
 
 

--- a/modules/opt04_tissue_function.py
+++ b/modules/opt04_tissue_function.py
@@ -11,6 +11,8 @@ from utils.mapping import *
 import glob
 import shutil
 
+turbo_mode = True  # When True, suppress interactive plotting
+
 
 def patlak_analysis_plotting(c_tissue, c_input, time):
     frame_no = len(time)
@@ -204,7 +206,9 @@ def plot_rois_and_curves(selected_voxels, data_4d, data_3d, T1_matrix, M0_matrix
     elif choice == 3: 
         plt.savefig(os.path.join(image_directory, 'Concentration Time Curves', 'Tissue', f'Mixed_Matter.png'), dpi=200)    
     plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()
+    if not turbo_mode:
+        close_plot_after_delay_plt(3)
+        plt.show()
     plt.tight_layout()
     plt.close()
 
@@ -260,7 +264,9 @@ def plot_time_intensity_curves_and_CTC_t2(data, data2, roi_voxels, roi_voxels_up
     plt.savefig(os.path.join(image_directory, 'Concentration Time Curves', 'Tissue', type, f'CTC+ROI_slice_{slice_index+1}_normalisation.png'), dpi=200)
     
     plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()
+    if not turbo_mode:
+        close_plot_after_delay_plt(3)
+        plt.show()
     plt.close()
 
     shift_manual = input('[!] Manually shift baseline point? (y/n): ')
@@ -277,7 +283,9 @@ def plot_time_intensity_curves_and_CTC_t2(data, data2, roi_voxels, roi_voxels_up
         ax.grid(which='minor', alpha=0.25)
         ax.minorticks_on()
         plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-        plt.show()
+        if not turbo_mode:
+            close_plot_after_delay_plt(3)
+            plt.show()
         plt.close()
         baseline_point = int(input('[!] Pick baseline point: '))
         avg_C_t = custom_shifter(avg_C_t_0, baseline_point)
@@ -310,7 +318,9 @@ def plot_time_intensity_curves_and_CTC_t2(data, data2, roi_voxels, roi_voxels_up
     plt.savefig(os.path.join(image_directory, 'Concentration Time Curves', 'Tissue', type, f'CTC+ROI_slice_{slice_index+1}.png'), dpi=200)
     
     plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
-    plt.show()
+    if not turbo_mode:
+        close_plot_after_delay_plt(3)
+        plt.show()
     plt.close()
 
     np.save(os.path.join(analysis_directory, 'CTC Data', 'Tissue', type, f'CTC_slice_{slice_index+1}.npy'), avg_C_t)
@@ -335,7 +345,8 @@ class ROISelector_tissue:
         self.fig.canvas.mpl_connect('button_press_event', self.onclick)
         self.fig.canvas.mpl_connect('key_press_event', self.on_key)
         self.redraw()
-        plt.show()
+        if not turbo_mode:
+            plt.show()
 
     def onclick(self, event):
         if event.inaxes != self.ax: return

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -6,6 +6,8 @@ from .kinetic_models import two_compartment_fit
 from scipy.optimize import curve_fit
 from termcolor import colored
 
+turbo_mode = True  # When True, suppress interactive plotting
+
 def permeability_user_interface(analysis_directory):
     subtype_mapping_artery = {
         "lica": "Left Interior Carotid",
@@ -124,9 +126,11 @@ def patlak_analysis(c_tissue, c_input, time, subtype_tissue, image_directory):
           f'$K_i = {round(Ki*6000, 5)} \pm {round(SD_Ki*6000, 5)}$ ml/100g/min, '
           f'$\\lambda = {round(lambda_*100, 5)}$ ml/100g')
     plt.grid(True)
-    plt.gcf().canvas.mpl_connect('key_press_event', on_esc) 
+    plt.gcf().canvas.mpl_connect('key_press_event', on_esc)
     plt.savefig(os.path.join(image_directory, 'Fit', f'patlak_{subtype_tissue}'),dpi=200)
-    plt.show()
+    if not turbo_mode:
+        close_plot_after_delay_plt(3)
+        plt.show()
     return Ki, lambda_, SD_Ki
 
 


### PR DESCRIPTION
## Summary
- add turbo mode support to option 0, 2, 4, and 5 modules
- register every option with turbo mode in `main.py`
- skip the image viewer when turbo mode is enabled

## Testing
- `python3 -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68529db695b88321ae80488378fe3274