### PR TITLE
Fix plot visibility in manual mode

### DIFF
--- a/modules/opt01_T1_fit.py
+++ b/modules/opt01_T1_fit.py
@@ -19,18 +19,16 @@ import threading
 turbo_mode = True #doesnt show plots
 
 def close_plot_after_delay_plt(delay):
-    """
-    Close the plot automatically after a delay if no interaction occurs.
-    :param delay: Time in seconds to wait before closing the plot.
-    """
-    def close():
-        plt.close(plt.gcf())  # Close the current figure
+    """Close the plot after ``delay`` seconds when running in turbo mode."""
+    if turbo_mode:
+        def close():
+            plt.close(plt.gcf())  # Close the current figure
 
-    timer = threading.Timer(delay, close)
-    timer.start()
+        timer = threading.Timer(delay, close)
+        timer.start()
 
-    # If there is user interaction, cancel the timer
-    plt.gcf().canvas.mpl_connect('key_press_event', lambda event: timer.cancel())
+        # If there is user interaction, cancel the timer
+        plt.gcf().canvas.mpl_connect('key_press_event', lambda event: timer.cancel())
 
 
 def extract_vfa_params(vfa_filenames, nifti_directory):

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -153,7 +153,7 @@ import threading
 
 
 def close_plot_after_delay_plt(delay, fig=None):
-    if not turbo_mode:
+    if turbo_mode:
         def close_plot():
             if fig:
                 plt.close(fig)
@@ -169,7 +169,7 @@ def close_plot_after_delay(delay, fig):
     :param delay: Time in seconds to wait before closing the plot.
     :param fig: The figure object to close.
     """
-    if not turbo_mode:
+    if turbo_mode:
         def close():
             plt.close(fig)
 
@@ -577,7 +577,7 @@ def close_plot_after_delay_special(delay, default_save_callback):
     :param delay: Time in seconds to wait before closing the plot.
     :param default_save_callback: Function to call for saving the default data.
     """
-    if not turbo_mode:
+    if turbo_mode:
         def close():
             default_save_callback()
             plt.close(plt.gcf())  # Close the current figure


### PR DESCRIPTION
## Summary
- stop internal plot timer in `opt01_T1_fit` when not running in turbo mode

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852b802c37c8321aff63d188832b424