### PR TITLE
Fix plot override in manual mode

### DIFF
--- a/main.py
+++ b/main.py
@@ -120,19 +120,17 @@ def manual_cli_loop(option, data_directory, analysis_directory, nifti_directory,
 def main():
     args = parse_args()
 
-    # Show figures when running interactively unless explicitly disabled via the
-    # ``PBRAIN_TURBO`` environment variable. The enumerator sets this variable to
-    # keep plotting off during batch processing.
-    if os.environ.get("PBRAIN_TURBO") != "1":
-        plotting.turbo_mode = False
-        opt01_T1_fit.turbo_mode = False
-        AI_input_functions.turbo_mode = False
-        AI_tissue_functions.turbo_mode = False
-        opt03_time_shifting.turbo_mode = False
-        opt02_input_functions.turbo_mode = False
-        opt04_tissue_function.turbo_mode = False
-        opt05_BBB_parameters.turbo_mode = False
-        opt00_images.turbo_mode = False
+    # Respect ``PBRAIN_TURBO`` to disable plotting when running in batch mode.
+    # Individual modes may override this later (manual/pseudo always show plots).
+    def set_turbo_mode(enabled: bool):
+        modules = [plotting, opt01_T1_fit, AI_input_functions, AI_tissue_functions,
+                   opt03_time_shifting, opt02_input_functions,
+                   opt04_tissue_function, opt05_BBB_parameters, opt00_images]
+        for m in modules:
+            m.turbo_mode = enabled
+
+    turbo_env = os.environ.get("PBRAIN_TURBO") == "1"
+    set_turbo_mode(turbo_env)
 
     if args.id:
         log_number = args.id
@@ -168,6 +166,7 @@ def main():
             return
 
     if mode == 'manual' or args.option is not None:
+        set_turbo_mode(False)
         manual_cli_loop(args.option, data_directory, analysis_directory, nifti_directory,
                         image_directory, filenames, parameters)
     elif mode == 'auto':
@@ -176,6 +175,7 @@ def main():
         input_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters)
         tissue_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters)
     elif mode == 'pseudo':
+        set_turbo_mode(False)
         print_banner()
         T1_fit(data_directory, analysis_directory, nifti_directory, image_directory, filenames, parameters)
         input_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters)

--- a/modules/opt01_T1_fit.py
+++ b/modules/opt01_T1_fit.py
@@ -19,18 +19,16 @@ import threading
 turbo_mode = True #doesnt show plots
 
 def close_plot_after_delay_plt(delay):
-    """
-    Close the plot automatically after a delay if no interaction occurs.
-    :param delay: Time in seconds to wait before closing the plot.
-    """
-    def close():
-        plt.close(plt.gcf())  # Close the current figure
+    """Close the plot after ``delay`` seconds when running in turbo mode."""
+    if turbo_mode:
+        def close():
+            plt.close(plt.gcf())  # Close the current figure
 
-    timer = threading.Timer(delay, close)
-    timer.start()
+        timer = threading.Timer(delay, close)
+        timer.start()
 
-    # If there is user interaction, cancel the timer
-    plt.gcf().canvas.mpl_connect('key_press_event', lambda event: timer.cancel())
+        # If there is user interaction, cancel the timer
+        plt.gcf().canvas.mpl_connect('key_press_event', lambda event: timer.cancel())
 
 
 def extract_vfa_params(vfa_filenames, nifti_directory):

--- a/utils/plotting.py
+++ b/utils/plotting.py
@@ -153,7 +153,7 @@ import threading
 
 
 def close_plot_after_delay_plt(delay, fig=None):
-    if not turbo_mode:
+    if turbo_mode:
         def close_plot():
             if fig:
                 plt.close(fig)
@@ -169,7 +169,7 @@ def close_plot_after_delay(delay, fig):
     :param delay: Time in seconds to wait before closing the plot.
     :param fig: The figure object to close.
     """
-    if not turbo_mode:
+    if turbo_mode:
         def close():
             plt.close(fig)
 
@@ -577,7 +577,7 @@ def close_plot_after_delay_special(delay, default_save_callback):
     :param delay: Time in seconds to wait before closing the plot.
     :param default_save_callback: Function to call for saving the default data.
     """
-    if not turbo_mode:
+    if turbo_mode:
         def close():
             default_save_callback()
             plt.close(plt.gcf())  # Close the current figure


### PR DESCRIPTION
## Summary
- centralize turbo mode handling
- force plotting on when manual or pseudo modes run

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6852b802c37c8321aff63d188832b424