### PR TITLE
Handle controls folder in GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ and will set this environment variable automatically. When a control run is
 processed, a small `control.json` file is written to the dataset directory.  The
 script accepts a list of log numbers or the `--all` flag. Combining
 `--controls` with `--all` processes every available control dataset.
+When the GUI encounters a `controls` folder it can be opened to reveal the
+contained datasets. A `controls.json` file is automatically created in this
+folder to indicate that its subfolders are control runs.
 
 Placing an `apply_jumpfix.json` file next to a dataset enables automatic
 correction of sudden signal jumps during the analysis.

--- a/modules/start.py
+++ b/modules/start.py
@@ -6,6 +6,7 @@ import sys
 import os
 import gzip
 import glob
+import json
 
 
 def print_banner():
@@ -27,79 +28,114 @@ def print_banner():
 
 
 availability_toggled = False
+
 def select_log_number():
+    """GUI for selecting a dataset."""
+
     global selected_log_number
-    
+
+    root = tk.Tk()
+    root.title('Select Log Number')
+    root.geometry("200x450")
+
+    frame = tk.Frame(root)
+    frame.pack(side=tk.TOP, fill=tk.BOTH, expand=tk.YES)
+
+    data_root = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 'Data')
+    current_path = data_root
+    log_numbers = []
+
+    log_numbers_listbox = tk.Listbox(frame, height=20, width=30)
+    log_numbers_listbox.pack(side=tk.TOP, padx=20, pady=5)
+
+    def ensure_controls_flag(path):
+        flag_path = os.path.join(path, 'controls.json')
+        if not os.path.exists(flag_path):
+            with open(flag_path, 'w') as f:
+                json.dump({"controls": True}, f, indent=4)
+
+    def refresh_list(path):
+        nonlocal current_path, log_numbers
+        current_path = path
+        if os.path.basename(current_path).lower() == 'controls':
+            ensure_controls_flag(current_path)
+        log_numbers = [f.name for f in os.scandir(current_path) if f.is_dir()]
+        log_numbers.sort()
+        log_numbers_listbox.delete(0, tk.END)
+        for item in log_numbers:
+            log_numbers_listbox.insert(tk.END, item)
+        log_numbers_listbox.yview(tk.END)
+        if current_path != data_root:
+            back_button.pack(side=tk.TOP, pady=5, anchor=tk.CENTER)
+        else:
+            back_button.pack_forget()
+
     def on_select(event):
         global selected_log_number
+        if not log_numbers_listbox.curselection():
+            return
         selected_log_number = log_numbers_listbox.get(log_numbers_listbox.curselection())
-        # Remove the asterisk from the selected log number if it exists
         selected_log_number = selected_log_number.rstrip('*')
 
-    
+    def on_double_click(event):
+        if not log_numbers_listbox.curselection():
+            return
+        item = log_numbers_listbox.get(log_numbers_listbox.curselection())
+        next_path = os.path.join(current_path, item)
+        if os.path.isdir(next_path) and current_path == data_root and item.lower() == 'controls':
+            refresh_list(next_path)
+        else:
+            on_select(None)
+            on_accept()
+
     def on_accept():
-        global selected_log_number 
+        global selected_log_number
         if selected_log_number:
             root.destroy()
-            
+
     def toggle_availability():
         global availability_toggled
         availability_toggled = not availability_toggled
-        # Save the current scrollbar position
         current_scroll = log_numbers_listbox.yview()
         for i, log in enumerate(log_numbers):
-            path_to_check = os.path.join(base_path, log, 'Analysis', 'values.json')
-            nifti_file_path = os.path.join(base_path, log, 'NIfTI', 'WIPDelRec-hperf120long.nii')
+            path_to_check = os.path.join(current_path, log, 'Analysis', 'values.json')
+            nifti_file_path = os.path.join(current_path, log, 'NIfTI', 'WIPDelRec-hperf120long.nii')
             nifti_file_exists = os.path.exists(nifti_file_path)
             if availability_toggled:
                 display_text = log
                 if nifti_file_exists:
                     display_text += '*'
-                    
                 if os.path.exists(path_to_check):
                     log_numbers_listbox.delete(i)
                     log_numbers_listbox.insert(i, display_text)
-                    log_numbers_listbox.itemconfig(i, {'fg':'green'})
+                    log_numbers_listbox.itemconfig(i, {'fg': 'green'})
                 else:
                     log_numbers_listbox.delete(i)
                     log_numbers_listbox.insert(i, display_text)
-                    log_numbers_listbox.itemconfig(i, {'fg':'red'})
+                    log_numbers_listbox.itemconfig(i, {'fg': 'red'})
             else:
                 log_numbers_listbox.delete(i)
                 log_numbers_listbox.insert(i, log)
-                log_numbers_listbox.itemconfig(i, {'fg':'white'})
+                log_numbers_listbox.itemconfig(i, {'fg': 'white'})
 
         log_numbers_listbox.yview_moveto(current_scroll[0])
-    root = tk.Tk()
-    root.title('Select Log Number')
-    root.geometry("200x450")
-    
-    frame = tk.Frame(root)
-    frame.pack(side=tk.TOP, fill=tk.BOTH, expand=tk.YES)
-    
-    base_path = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 'Data')
-    log_numbers = [f.name for f in os.scandir(base_path) if f.is_dir()]
-    log_numbers.sort()
-    
-    log_numbers_listbox = tk.Listbox(frame, height=20, width=30)
-    log_numbers_listbox.pack(side=tk.TOP, padx=20, pady=5)  # Horizontally centered using padx
-    
-    for item in log_numbers:
-        log_numbers_listbox.insert(tk.END, item)
-        
-    log_numbers_listbox.yview(tk.END)
-    log_numbers_listbox.bind('<<ListboxSelect>>', on_select)
-    
-    availability_toggled = False
-    
+
+    def go_back():
+        refresh_list(data_root)
+
     accept_button = ttk.Button(root, text="Accept", command=on_accept)
-    accept_button.pack(side=tk.TOP, pady=5, anchor=tk.CENTER)
-    
     availability_button = ttk.Button(root, text="Availability", command=toggle_availability)
+    back_button = ttk.Button(root, text="Back", command=go_back)
+
+    accept_button.pack(side=tk.TOP, pady=5, anchor=tk.CENTER)
     availability_button.pack(side=tk.TOP, pady=5, anchor=tk.CENTER)
-    
+
+    refresh_list(data_root)
+
+    log_numbers_listbox.bind('<<ListboxSelect>>', on_select)
+    log_numbers_listbox.bind('<Double-1>', on_double_click)
+
     selected_log_number = None
-    
     root.mainloop()
     root.update()
     return selected_log_number


### PR DESCRIPTION
## Summary
- allow GUI navigation into `Data/controls` and back
- create a `controls.json` flag when entering the controls folder
- document controls folder behaviour in README

## Testing
- `python3 -m py_compile modules/start.py`
- `python3 -m py_compile enumerator.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6852bd7c7004832180c013d08bb59017