### PR TITLE
Update manual and pseudo mode menus

### DIFF
--- a/enumerator.py
+++ b/enumerator.py
@@ -56,7 +56,8 @@ else:
     sys.exit(1)
 
 # Template for the command to run
-command_template = "python3 main.py --id {} --option 6"
+# Use the dedicated automatic mode instead of the manual option.
+command_template = "python3 main.py --id {} --mode auto"
 
 # Iterate through datasets and execute the command
 for id, is_control in datasets:

--- a/main.py
+++ b/main.py
@@ -44,13 +44,20 @@ def parse_args():
 
 
 def manual_cli_loop(option, data_directory, analysis_directory, nifti_directory,
-                    image_directory, filenames, parameters):
-    """Run the classic CLI interface."""
+                    image_directory, filenames, parameters, pseudo: bool = False):
+    """Run the classic CLI interface.
+
+    When ``pseudo`` is True the menu text changes to reflect that the automatic
+    pipeline has already been executed.
+    """
     while True:
         if option is not None:
             choice = option
         else:
-            welcome_screen()
+            if pseudo:
+                welcome_screen_pseudo()
+            else:
+                welcome_screen()
             choice = welcome_screen_choice()
 
         if choice == 0:
@@ -85,12 +92,12 @@ def manual_cli_loop(option, data_directory, analysis_directory, nifti_directory,
             if option is not None:
                 break
 
-        elif choice == 7:
+        elif choice == 6:
             add_notes(analysis_directory)
             if option is not None:
                 break
 
-        elif choice == 8:
+        elif choice == 7:
             selected_addon = list_addons()
             load_addon(selected_addon, analysis_directory, nifti_directory,
                        image_directory, filenames, parameters)
@@ -99,15 +106,6 @@ def manual_cli_loop(option, data_directory, analysis_directory, nifti_directory,
                 break
 
         elif choice == 9:
-            break
-
-        elif choice == 6:
-            T1_fit(data_directory, analysis_directory, nifti_directory,
-                   image_directory, filenames, parameters)
-            input_function_AI(analysis_directory, nifti_directory, image_directory,
-                               filenames, parameters)
-            tissue_function_AI(analysis_directory, nifti_directory, image_directory,
-                                filenames, parameters)
             break
 
         elif choice == 66:
@@ -181,6 +179,6 @@ def main():
         input_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters)
         tissue_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters)
         manual_cli_loop(None, data_directory, analysis_directory, nifti_directory,
-                        image_directory, filenames, parameters)
+                        image_directory, filenames, parameters, pseudo=True)
 if __name__ == '__main__':
     main()

--- a/modules/start.py
+++ b/modules/start.py
@@ -158,15 +158,28 @@ def welcome_screen():
     print('| '+colored('3', 'cyan')+' | Generate Time-Shifted Concentration Curves (TSCC) from CTC')
     print('| '+colored('4', 'cyan')+' | Create Tissue (Grey/White matter) CTCs')
     print('| '+colored('5', 'cyan')+' | Compute BBB permeability and perfusion parameters')
-    #print('| '+colored('6', 'cyan')+' | Cross-sequence axial reconstructions')
-    print('| '+colored('6', 'cyan')+' | Full automatic AI enhanced analysis')
-    print('| '+colored('7', 'cyan')+' | Add analysis notes')
-    print('| '+colored('8', 'cyan')+' | Addons')
+    print('| '+colored('6', 'cyan')+' | Add analysis notes')
+    print('| '+colored('7', 'cyan')+' | Addons')
+    print('| '+colored('9', 'red')+' | ' +colored('Exit program', 'red'))
+    print(colored('=-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-=', 'white'))
+
+def welcome_screen_pseudo():
+    """Menu shown after running the automatic pipeline in pseudo mode."""
+    print_banner()
+    print(colored('=-=-= Choose between the following options =-=-==-=-==-=-==-=-=-=-=', 'white'))
+    print('| '+colored('0', 'cyan')+' | View MRI images')
+    print('| '+colored('1', 'cyan')+' | Compute M0 and T1 map from MRI data')
+    print('| '+colored('2', 'cyan')+' | Change Input Function')
+    print('| '+colored('3', 'cyan')+' | Generate Time-Shifted Concentration Curves (TSCC) from CTC')
+    print('| '+colored('4', 'cyan')+' | Change Tissue (Grey/White matter) CTCs')
+    print('| '+colored('5', 'cyan')+' | Compute BBB permeability and perfusion parameters')
+    print('| '+colored('6', 'cyan')+' | Add analysis notes')
+    print('| '+colored('7', 'cyan')+' | Addons')
     print('| '+colored('9', 'red')+' | ' +colored('Exit program', 'red'))
     print(colored('=-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-==-=-=', 'white'))
     
 def welcome_screen_choice():
-    choice = input('['+colored('!', 'cyan')+'] Enter option ('+colored('1', 'cyan')+'-'+colored('9', 'cyan')+'): ')
+    choice = input('['+colored('!', 'cyan')+'] Enter option ('+colored('1', 'cyan')+'-'+colored('7', 'cyan')+', or 9 to exit): ')
     
     if not choice.isdigit():
         print('[' +colored('!', 'red') +"] Only integer input!")


### PR DESCRIPTION
## Summary
- remove automatic mode entry from manual options
- shift numbering for manual options
- add pseudo-mode menu and use it after automatic pipeline
- call automatic mode directly in `enumerator.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`
- `python main.py --mode auto --id test` *(fails: waiting for data)*

------
https://chatgpt.com/codex/tasks/task_e_6852c0e7e3908321af96a4ead3e4150a