### PR TITLE
Add dual kinetic model mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,10 +248,11 @@ Pre-trained models are available at
 into the `AI/` directory so the default paths resolve.
 
 ### Kinetic model selection
-The permeability analysis defaults to Patlak modelling. Set the variable
-`KINETIC_MODEL` in `utils/settings.py` or export the environment variable
-`P_BRAIN_MODEL` to `two_compartment` to use the extended Tofts
-two-compartment fit instead.
+The permeability analysis defaults to executing both Patlak and
+Tikhonov (two-compartment) fits.  Adjust the variable `KINETIC_MODEL` in
+`utils/settings.py` or export the environment variable `P_BRAIN_MODEL`
+with one of `patlak`, `tikhonov` or `both` to control which models are
+run.
 
 ## 7. Contributions
 For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -173,26 +173,41 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
     C_t = C_t[0:len(C_a)]
     time_points_s = time_points_s[0:len(C_a)]
     
-    if KINETIC_MODEL.lower() == 'two_compartment':
+    model = KINETIC_MODEL.lower()
+    use_tikhonov = model in ('two_compartment', 'tikhonov', 'both')
+    use_patlak = model in ('patlak', 'both')
+
+    if use_tikhonov:
         Ki, lamda, SD_Ki = two_compartment_fit(C_a, C_t, time_points_s)
         print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
               f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
         P, P_std = Ki, SD_Ki
-    else:
-        Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
-        baseline_point = find_shifted_baseline(C_t)+1
-        P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
-        print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
-        print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
-        
-    values = [f"Ki: {Ki*6000} (+- {SD_Ki*6000})",f"lambda: {lamda*100}", f"Tissue type: {subtype_tissue} (Slice {slice_tissue})", f"Artery type: {subtype_artery} (Venous Slice {venous_slice}, Arterial Slice {arterial_slice})", f"Ki_et: {P} +- ({P_std})"]
-        
-    save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue, subtype_artery, venous_slice, arterial_slice, analysis_directory)
+        save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
+                    subtype_artery, venous_slice, arterial_slice,
+                    analysis_directory, suffix='_tikhonov')
 
-    if subtype_artery == 'Max':    
-        json1 = os.path.join(analysis_directory, 'values.json')
-        json2 = os.path.join(analysis_directory, 'max_info.json')
-        replace_max_with_artery_type_and_delete(json1, json2)
+    if use_patlak:
+        Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s,
+                                          subtype_tissue, image_directory)
+        baseline_point = find_shifted_baseline(C_t)+1
+        P, P_std = compute_average_permeability(C_a, C_t, time_points_s,
+                                               baseline_point=baseline_point)
+        print('[!] Advanced computation of permeability: (', P, '+-', P_std,
+              ') ml/100g/min')
+        print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
+        save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
+                    subtype_artery, venous_slice, arterial_slice,
+                    analysis_directory, suffix='_patlak')
+
+    if subtype_artery == 'Max':
+        if use_tikhonov:
+            json1 = os.path.join(analysis_directory, 'values_tikhonov.json')
+            json2 = os.path.join(analysis_directory, 'max_info.json')
+            replace_max_with_artery_type_and_delete(json1, json2)
+        if use_patlak:
+            json1 = os.path.join(analysis_directory, 'values_patlak.json')
+            json2 = os.path.join(analysis_directory, 'max_info.json')
+            replace_max_with_artery_type_and_delete(json1, json2)
     restart_prompt = input('[!] Repeat analysis? (y/n): ')
     if restart_prompt.lower() == 'y':    
         subtype_tissue, subtype_artery, slice_tissue, (venous_slice, arterial_slice) = permeability_user_interface(analysis_directory)
@@ -203,25 +218,38 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         C_t = C_t[0:len(C_a)]
         time_points_s = time_points_s[0:len(C_a)]
         
-        if KINETIC_MODEL.lower() == 'two_compartment':
+        model = KINETIC_MODEL.lower()
+        use_tikhonov = model in ('two_compartment', 'tikhonov', 'both')
+        use_patlak = model in ('patlak', 'both')
+
+        if use_tikhonov:
             Ki, lamda, SD_Ki = two_compartment_fit(C_a, C_t, time_points_s)
             print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
                   f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
             P, P_std = Ki, SD_Ki
-        else:
+            save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
+                        subtype_artery, venous_slice, arterial_slice,
+                        analysis_directory, suffix='_tikhonov')
+
+        if use_patlak:
             Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
             baseline_point = find_shifted_baseline(C_t)+1
             P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
             print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
             print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
-            
-        values = [f"Ki: {Ki*6000} (+- {SD_Ki*6000})",f"lambda: {lamda*100}", f"Tissue type: {subtype_tissue} (Slice {slice_tissue})", f"Artery type: {subtype_artery} (Venous Slice {venous_slice}, Arterial Slice {arterial_slice})", f"Ki_et: {P} +- ({P_std})"]
-        save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue, subtype_artery, venous_slice, arterial_slice, analysis_directory)
-        
-        if subtype_artery == 'Max':    
-            json1 = os.path.join(analysis_directory, 'values.json')
-            json2 = os.path.join(analysis_directory, 'max_info.json')
-            replace_max_with_artery_type_and_delete(json1, json2)
+            save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
+                        subtype_artery, venous_slice, arterial_slice,
+                        analysis_directory, suffix='_patlak')
+
+        if subtype_artery == 'Max':
+            if use_tikhonov:
+                json1 = os.path.join(analysis_directory, 'values_tikhonov.json')
+                json2 = os.path.join(analysis_directory, 'max_info.json')
+                replace_max_with_artery_type_and_delete(json1, json2)
+            if use_patlak:
+                json1 = os.path.join(analysis_directory, 'values_patlak.json')
+                json2 = os.path.join(analysis_directory, 'max_info.json')
+                replace_max_with_artery_type_and_delete(json1, json2)
         leaver()  
     else:
         leaver()  

--- a/utils/loading.py
+++ b/utils/loading.py
@@ -76,8 +76,11 @@ def find_matching_file(directory, pattern):
             return os.path.join(directory, filename)
     return None
 
-def save_values(Ki, SD_Ki, lambda_, P, P_std, subtype_tissue, slice_tissue, subtype_artery, venous_slice, arterial_slice, analysis_directory):
-    values_file_path = os.path.join(analysis_directory, 'values.json')
+def save_values(Ki, SD_Ki, lambda_, P, P_std, subtype_tissue, slice_tissue,
+                subtype_artery, venous_slice, arterial_slice,
+                analysis_directory, suffix=""):
+    """Save permeability results to ``values{suffix}.json``."""
+    values_file_path = os.path.join(analysis_directory, f'values{suffix}.json')
     
     if os.path.exists(values_file_path):
         with open(values_file_path, 'r') as f:

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -15,7 +15,11 @@ MULTIPROCESSING = True
 # Default number of CPU cores used when multiprocessing is enabled
 NUMBER_OF_CORES = int(os.environ.get("P_BRAIN_CORES", 4))
 
-KINETIC_MODEL = os.environ.get("P_BRAIN_MODEL", "patlak")
+# Select kinetic modelling strategy. Valid options are ``patlak``,
+# ``tikhonov`` (two-compartment fit) or ``both`` to execute the two
+# approaches sequentially.  When the environment variable
+# ``P_BRAIN_MODEL`` is not provided the default is ``both``.
+KINETIC_MODEL = os.environ.get("P_BRAIN_MODEL", "both")
 
 # Paths to the neural network models used for artery and vein ROI extraction.
 # These can be overridden by environment variables to use custom models.


### PR DESCRIPTION
## Summary
- support Patlak, Tikhonov or both kinetic models
- document kinetic model choices in README
- store results in values_patlak.json and values_tikhonov.json

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68666b0416f48321a3b4547c5a8366d5