### PR TITLE
Fix missing directory before saving images

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,9 @@ run. When both models are executed, output files are suffixed with
 `_patlak` and `_tikhonov` respectively.
 Image outputs are stored in `AI_patlak/` and `AI_tikhonov/` subfolders
 under the main `Images` directory.
+During execution the files are first written to an `AI/` directory and
+renamed to the model-specific location by the script once processing
+completes.
 
 ## 7. Contributions
 For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -1418,6 +1418,8 @@ def plot_ctcs_and_patlak(
 
     plt.tight_layout()
     if save_path:
+        # Ensure the destination directory exists before saving
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
         plt.savefig(save_path, dpi=300, bbox_inches='tight')
     plt.close(fig)
 
@@ -1740,7 +1742,10 @@ def compute_and_plot_ctcs_median(
         if boundary:
             Ki_boundary_image[:, :, i][boundary_mask] = Ki_boundary
 
-        # Plot the results for the current slice
+        # Plot the results for the current slice. Images are always written
+        # under ``AI/Tissue functions`` so that ``_rename_model_outputs`` can
+        # move the entire directory to ``AI_patlak`` or ``AI_tikhonov`` after
+        # the model run completes.
         plot_ctcs_and_patlak(
             t2_img[:, :, i], data_4d[:, :, i, 20],
             wm_slice_t2, cortical_gm_slice_t2, subcortical_gm_slice_t2,


### PR DESCRIPTION
## Summary
- ensure output directory exists when saving tissue function plots
- document that the directory is renamed for each kinetic model

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866804c70d88321ba8605c19027b67b