### PR TITLE
Add Tikhonov regularised two-compartment model

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,9 @@ into the `AI/` directory so the default paths resolve.
 
 ### Kinetic model selection
 The permeability analysis defaults to executing both Patlak and
-Tikhonov (two-compartment) fits.  Adjust the variable `KINETIC_MODEL` in
+Tikhonov (two-compartment) fits.  The Tikhonov option solves the extended
+Tofts model with Tikhonov regularisation and estimates plasma volume, Ki and CBF
+via model-free deconvolution. Adjust the variable `KINETIC_MODEL` in
 `utils/settings.py` or export the environment variable `P_BRAIN_MODEL`
 with one of `patlak`, `tikhonov` or `both` to control which models are
 run. When both models are executed, output files are suffixed with

--- a/modules/kinetic_models.py
+++ b/modules/kinetic_models.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.optimize import curve_fit
+from scipy.optimize import curve_fit, least_squares
 
 
 def extended_tofts_model(t, Ktrans, ve, vp, Cp):
@@ -37,3 +37,78 @@ def two_compartment_fit(c_input, c_tissue, time_array):
     fitted_curve = extended_tofts_model(time_array, Ktrans_fitted, ve_fitted, vp_fitted, c_input)
 
     return Ki, lambda_val, Ki_std, fitted_curve
+
+
+def construct_convolution_matrix(C_a, delta_t):
+    """Build a Toeplitz matrix for convolution."""
+    n = len(C_a)
+    A = np.zeros((n, n))
+    for i in range(n):
+        A[i, : i + 1] = C_a[i::-1] * delta_t
+    return A
+
+
+def tikhonov_regularization(A, C_t, lambd):
+    """Solve A x = C_t with Tikhonov regularisation."""
+    n = A.shape[1]
+    L = np.eye(n)
+    ATA = A.T @ A
+    LTL = L.T @ L
+    regularized = ATA + lambd * LTL
+    return np.linalg.solve(regularized, A.T @ C_t)
+
+
+def two_compartment_tikhonov_fit(c_input, c_tissue, time_array, lambd=0.1):
+    """Fit the extended Tofts model using Tikhonov regularisation.
+
+    Parameters
+    ----------
+    c_input : array_like
+        Arterial input function.
+    c_tissue : array_like
+        Measured tissue concentration curve.
+    time_array : array_like
+        Time points in seconds.
+    lambd : float, optional
+        Regularisation weight.
+
+    Returns
+    -------
+    Ki : float
+        Permeability in ml/100g/min.
+    lam : float
+        Dimensionless lambda (100*ve).
+    vp : float
+        Plasma volume fraction.
+    CBF : float
+        Cerebral blood flow in ml/100g/min estimated from deconvolution.
+    fitted_curve : ndarray
+        Model prediction at ``time_array``.
+    """
+
+    if c_input.shape[0] != c_tissue.shape[0]:
+        raise ValueError("The number of time points in c_input and c_tissue must be the same.")
+
+    initial_guess = [0.5 / 6000, 0.2, 0.05]
+
+    def model(params):
+        return extended_tofts_model(time_array, params[0], params[1], params[2], c_input)
+
+    def objective(params):
+        return np.concatenate([model(params) - c_tissue, np.sqrt(lambd) * params])
+
+    res = least_squares(objective, initial_guess, bounds=(0, np.inf))
+    Ktrans_fitted, ve_fitted, vp_fitted = res.x
+
+    Ki = Ktrans_fitted * 6000
+    lam = ve_fitted * 100
+
+    fitted_curve = model(res.x)
+
+    # Estimate CBF using model-free deconvolution
+    delta_t = np.diff(time_array)[0]
+    A = construct_convolution_matrix(c_input, delta_t)
+    residue = tikhonov_regularization(A, c_tissue, lambd)
+    CBF = residue[0] * 6000
+
+    return Ki, lam, vp_fitted, CBF, fitted_curve

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -2,7 +2,8 @@ from utils.plotting import *
 from utils.mapping import *
 from utils.loading import *
 import utils.settings as settings
-from .kinetic_models import two_compartment_fit
+from .kinetic_models import two_compartment_fit, two_compartment_tikhonov_fit
+import numpy as np
 from scipy.optimize import curve_fit
 from termcolor import colored
 
@@ -178,10 +179,11 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
     use_patlak = model in ('patlak', 'both')
 
     if use_tikhonov:
-        Ki, lamda, SD_Ki, _ = two_compartment_fit(C_a, C_t, time_points_s)
+        Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(C_a, C_t, time_points_s)
+        SD_Ki = np.nan
         print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
-              f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
-        P, P_std = Ki, SD_Ki
+              f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
+        P, P_std = Ki, 0.0
         save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
                     subtype_artery, venous_slice, arterial_slice,
                     analysis_directory, suffix='_tikhonov')
@@ -222,10 +224,11 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         use_patlak = model in ('patlak', 'both')
 
         if use_tikhonov:
-            Ki, lamda, SD_Ki, _ = two_compartment_fit(C_a, C_t, time_points_s)
+            Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(C_a, C_t, time_points_s)
+            SD_Ki = np.nan
             print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
-                  f'lambda: {lamda:.5f} ml/100g, SD_Ki: {SD_Ki:.5f}')
-            P, P_std = Ki, SD_Ki
+                  f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
+            P, P_std = Ki, 0.0
             save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
                         subtype_artery, venous_slice, arterial_slice,
                         analysis_directory, suffix='_tikhonov')


### PR DESCRIPTION
## Summary
- implement a Tikhonov regularised fit for the two-compartment model
- expose the new fit for ROI analysis
- document the behaviour in the kinetic model selection section

## Testing
- `python -m py_compile modules/kinetic_models.py modules/opt05_BBB_parameters.py`

------
https://chatgpt.com/codex/tasks/task_e_6867f7d13ee083218d815d84e1dc2e1f