### PR TITLE
Implement two-compartment ROI computation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Author: Edis Devin Tireli, M.Sc, Ph.D. student
 Affiliation: [Copenhagen University](https://www.ku.dk/english/)
 
 ## Motivation
-Understanding blood-brain barrier permeability is essential for assessing neurological disease and treatment response. _p_-Brain integrates segmentation, neural network-based ROI detection, and advanced kinetic modeling to compute the blood-brain barrier permeability (Ki) and cerebral blood flow (CBF). The toolkit can operate fully automatically, minimizing user error while allowing manual ROI delineation when desired. Patlak analysis, Tikhonov model-free deconvolution and Fick's two-compartment model underpin the Ki estimation workflow.
+Understanding blood-brain barrier permeability is essential for assessing neurological disease and treatment response. _p_-Brain integrates segmentation, neural network-based ROI detection, and advanced kinetic modeling to compute the blood-brain barrier permeability (Ki) and cerebral blood flow (CBF). The toolkit can operate fully automatically, minimizing user error while allowing manual ROI delineation when desired. Patlak analysis and a regularised two-compartment model underpin the Ki estimation workflow.
 
 
 # Table of Contents
@@ -249,20 +249,20 @@ into the `AI/` directory so the default paths resolve.
 
 ### Kinetic model selection
 The permeability analysis defaults to executing both Patlak and
-Tikhonov (two-compartment) fits.  The Tikhonov option solves the extended
-Tofts model with Tikhonov regularisation and estimates plasma volume, Ki and CBF
+two-compartment fits.  The two-compartment option solves the extended
+Tofts model with regularisation and estimates plasma volume, Ki and CBF
 via model-free deconvolution. Adjust the variable `KINETIC_MODEL` in
 `utils/settings.py` or export the environment variable `P_BRAIN_MODEL`
-with one of `patlak`, `tikhonov` or `both` to control which models are
+with one of `patlak`, `two_compartment` or `both` to control which models are
 run. When both models are executed, output files are suffixed with
-`_patlak` and `_tikhonov` respectively.
-Image outputs are stored in `AI_patlak/` and `AI_tikhonov/` subfolders
+`_patlak` and `_two_compartment` respectively.
+Image outputs are stored in `AI_patlak/` and `AI_two_compartment/` subfolders
 under the main `Images` directory.
 During execution the files are first written to an `AI/` directory and
 renamed to the model-specific location by the script once processing
 completes.
-When running the Tikhonov model the tissue function slice images display the
-two-compartment fit instead of the Patlak plot.
+When running the two-compartment model the tissue function slice images display
+the two-compartment fit instead of the Patlak plot.
 
 ## 7. Contributions
 For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -22,7 +22,7 @@ import utils.settings as settings
 from utils.fonts import *
 from utils.loading import *
 from utils.plotting import *
-from .kinetic_models import two_compartment_fit
+from .kinetic_models import two_compartment_tikhonov_fit
 from skimage.transform import resize
 import json
 from scipy.ndimage import binary_dilation
@@ -40,6 +40,14 @@ def patlak_total(C_t, C_a, t):
         bad = None
     Ki, lam, SD, *_ = patlak_with_exclusions(C_t, C_a, t, bad_mask=bad)
     return Ki, lam, SD
+
+def two_compartment_tikhonov(aif, tissue_curve, *, time_array, lambd=0.1):
+    """Two-compartment fit using Tikhonov regularisation."""
+    Ki, lam, _, _, fit_curve = two_compartment_tikhonov_fit(
+        aif, tissue_curve, time_array, lambd=lambd
+    )
+    SD_Ki = np.nan
+    return Ki, lam, SD_Ki, fit_curve
 
 def mask_problematic(ctc, *, tail_start: int = 100, thresh_factor: float = 0.5):
     """
@@ -1718,7 +1726,9 @@ def compute_and_plot_ctcs_median(
             if C_t.size == 0:
                 return (np.nan, np.nan, np.nan, None, np.array([], dtype=bool))
             if settings.KINETIC_MODEL.lower() == 'two_compartment':
-                Ki, lam, SD_Ki, fit_curve = two_compartment_fit(C_a_slice, C_t, time_points)
+                Ki, lam, SD_Ki, fit_curve = two_compartment_tikhonov(
+                    C_a_slice, C_t, time_array=time_points
+                )
                 return Ki, lam, SD_Ki, fit_curve, np.array([], dtype=bool)
             else:
                 Ki, lam, SD_Ki, x_patlak, y_patlak, included = patlak_analysis_plotting(C_t, C_a_slice, time_points)
@@ -1764,7 +1774,7 @@ def compute_and_plot_ctcs_median(
 
         # Plot the results for the current slice. Images are always written
         # under ``AI/Tissue functions`` so that ``_rename_model_outputs`` can
-        # move the entire directory to ``AI_patlak`` or ``AI_tikhonov`` after
+        # move the entire directory to ``AI_patlak`` or ``AI_two_compartment`` after
         # the model run completes.
         fit_curves = {
             'wm': curve_wm,
@@ -2097,8 +2107,10 @@ def compute_and_plot_ctcs_median(
         if not C_t.size:
             return np.nan, np.nan, np.nan
         if settings.KINETIC_MODEL.lower() == 'two_compartment':
-            Ki, lam, SD, _ = two_compartment_fit(C_a_total, C_t, time_points_total)
-            return Ki, lam, SD
+            Ki, lam, SD_Ki, _ = two_compartment_tikhonov(
+                C_a_total, C_t, time_array=time_points_total
+            )
+            return Ki, lam, SD_Ki
         if correct_signal_jumps:
             _, bad, _ = mask_problematic(C_t)
         else:
@@ -2302,6 +2314,7 @@ def plot_CBF_overlay(dce_slice, CBF_slice, slice_idx, save_path, vmin, vmax):
 def _rename_model_outputs(analysis_directory, image_directory, suffix, boundary=False):
     """Rename analysis outputs with a model-specific suffix."""
     import shutil
+    import glob
 
     files = [
         'Ki_wm.nii.gz',
@@ -2338,6 +2351,16 @@ def _rename_model_outputs(analysis_directory, image_directory, suffix, boundary=
         if os.path.exists(dst_dir):
             shutil.rmtree(dst_dir)
         os.rename(ai_dir, dst_dir)
+
+    if suffix == '_two_compartment':
+        old_files = glob.glob(os.path.join(analysis_directory, '*_tikhonov*'))
+        for path in old_files:
+            new_name = os.path.basename(path).replace('_tikhonov', suffix)
+            os.rename(path, os.path.join(analysis_directory, new_name))
+        old_dir = os.path.join(image_directory, 'AI_tikhonov')
+        new_dir = os.path.join(image_directory, 'AI_two_compartment')
+        if os.path.exists(old_dir) and not os.path.exists(new_dir):
+            os.rename(old_dir, new_dir)
 
 
 def _tissue_function_AI(model, analysis_directory, nifti_directory, image_directory, filenames, parameters):
@@ -2472,7 +2495,7 @@ def _tissue_function_AI(model, analysis_directory, nifti_directory, image_direct
 def tissue_function_AI(analysis_directory, nifti_directory, image_directory, filenames, parameters):
     """Run tissue function analysis using the configured kinetic model."""
     model_setting = settings.KINETIC_MODEL.lower()
-    models = ['patlak', 'tikhonov'] if model_setting == 'both' else [model_setting]
+    models = ['patlak', 'two_compartment'] if model_setting == 'both' else [model_setting]
     ai_base = os.path.join(image_directory, 'AI')
     for m in models:
         print(f'[!] Running {m} model')

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -2,7 +2,7 @@ from utils.plotting import *
 from utils.mapping import *
 from utils.loading import *
 import utils.settings as settings
-from .kinetic_models import two_compartment_fit, two_compartment_tikhonov_fit
+from .kinetic_models import two_compartment_tikhonov_fit
 import numpy as np
 from scipy.optimize import curve_fit
 from termcolor import colored
@@ -175,18 +175,22 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
     time_points_s = time_points_s[0:len(C_a)]
     
     model = settings.KINETIC_MODEL.lower()
-    use_tikhonov = model in ('two_compartment', 'tikhonov', 'both')
+    use_two_compartment = model in ('two_compartment', 'both')
     use_patlak = model in ('patlak', 'both')
 
-    if use_tikhonov:
-        Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(C_a, C_t, time_points_s)
+    if use_two_compartment:
+        Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(
+            C_a, C_t, time_points_s
+        )
         SD_Ki = np.nan
         print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
               f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
-        P, P_std = Ki, 0.0
-        save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
-                    subtype_artery, venous_slice, arterial_slice,
-                    analysis_directory, suffix='_tikhonov')
+        save_values(
+            Ki, SD_Ki, lamda, Ki, 0.0,
+            subtype_tissue, slice_tissue,
+            subtype_artery, venous_slice, arterial_slice,
+            analysis_directory, suffix='_two_compartment'
+        )
 
     if use_patlak:
         Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s,
@@ -202,8 +206,8 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
                     analysis_directory, suffix='_patlak')
 
     if subtype_artery == 'Max':
-        if use_tikhonov:
-            json1 = os.path.join(analysis_directory, 'values_tikhonov.json')
+        if use_two_compartment:
+            json1 = os.path.join(analysis_directory, 'values_two_compartment.json')
             json2 = os.path.join(analysis_directory, 'max_info.json')
             replace_max_with_artery_type_and_delete(json1, json2)
         if use_patlak:
@@ -220,18 +224,22 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         C_t = C_t[0:len(C_a)]
         time_points_s = time_points_s[0:len(C_a)]
         model = settings.KINETIC_MODEL.lower()
-        use_tikhonov = model in ('two_compartment', 'tikhonov', 'both')
+        use_two_compartment = model in ('two_compartment', 'both')
         use_patlak = model in ('patlak', 'both')
 
-        if use_tikhonov:
-            Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(C_a, C_t, time_points_s)
+        if use_two_compartment:
+            Ki, lamda, vp, CBF, _ = two_compartment_tikhonov_fit(
+                C_a, C_t, time_points_s
+            )
             SD_Ki = np.nan
             print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
                   f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
-            P, P_std = Ki, 0.0
-            save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,
-                        subtype_artery, venous_slice, arterial_slice,
-                        analysis_directory, suffix='_tikhonov')
+            save_values(
+                Ki, SD_Ki, lamda, Ki, 0.0,
+                subtype_tissue, slice_tissue,
+                subtype_artery, venous_slice, arterial_slice,
+                analysis_directory, suffix='_two_compartment'
+            )
 
         if use_patlak:
             Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
@@ -244,8 +252,8 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
                         analysis_directory, suffix='_patlak')
 
         if subtype_artery == 'Max':
-            if use_tikhonov:
-                json1 = os.path.join(analysis_directory, 'values_tikhonov.json')
+            if use_two_compartment:
+                json1 = os.path.join(analysis_directory, 'values_two_compartment.json')
                 json2 = os.path.join(analysis_directory, 'max_info.json')
                 replace_max_with_artery_type_and_delete(json1, json2)
             if use_patlak:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,58 @@
+import importlib.util
+import types
+import numpy as np
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, ROOT)
+os.environ["MPLBACKEND"] = "Agg"
+import matplotlib
+matplotlib.use = lambda *a, **k: None
+
+modules_pkg = types.ModuleType('modules')
+sys.modules['modules'] = modules_pkg
+
+spec_km = importlib.util.spec_from_file_location('modules.kinetic_models', os.path.join(ROOT, 'modules', 'kinetic_models.py'))
+km = importlib.util.module_from_spec(spec_km)
+sys.modules['modules.kinetic_models'] = km
+spec_km.loader.exec_module(km)
+
+spec_ai = importlib.util.spec_from_file_location('modules.AI_tissue_functions', os.path.join(ROOT, 'modules', 'AI_tissue_functions.py'), submodule_search_locations=[os.path.join(ROOT, 'modules')])
+ai = importlib.util.module_from_spec(spec_ai)
+sys.modules['modules.AI_tissue_functions'] = ai
+spec_ai.loader.exec_module(ai)
+patlak_total = ai.patlak_total
+two_compartment = ai.two_compartment_tikhonov
+
+
+def synthetic_data():
+    t = np.linspace(0, 60, 40)
+    aif = np.exp(-t / 10)
+    # Generate tissue curve using simple extended Tofts model
+    Ktrans = 0.001
+    ve = 0.2
+    vp = 0.05
+    conv = np.zeros_like(t)
+    for i in range(len(t)):
+        integ = np.trapz(aif[:i + 1] * np.exp(-(t[i] - t[:i + 1]) * Ktrans / ve), x=t[:i + 1])
+        conv[i] = integ
+    tissue = Ktrans * conv + vp * aif
+    noise = 0.01 * np.random.randn(*tissue.shape)
+    return t, aif, tissue + noise
+
+
+def test_models_differ():
+    t, ca, ct = synthetic_data()
+    ki_p, lam_p, _ = patlak_total(ct, ca, t)
+    ki_t, _, _, _ = two_compartment(ca, ct, time_array=t)
+    assert np.isfinite(ki_t)
+    assert not np.isclose(ki_p, ki_t)
+
+
+def test_two_compartment_handles_constant_aif():
+    t = np.linspace(0, 60, 20)
+    ca = np.ones_like(t)
+    ct = np.ones_like(t) * 0.2
+    ki, _, _, _ = two_compartment(ca, ct, time_array=t)
+    assert np.isfinite(ki)

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -16,7 +16,7 @@ MULTIPROCESSING = True
 NUMBER_OF_CORES = int(os.environ.get("P_BRAIN_CORES", 4))
 
 # Select kinetic modelling strategy. Valid options are ``patlak``,
-# ``tikhonov`` (two-compartment fit) or ``both`` to execute the two
+# ``two_compartment`` (regularised two-compartment fit) or ``both`` to execute the two
 # approaches sequentially.  When the environment variable
 # ``P_BRAIN_MODEL`` is not provided the default is ``both``.
 KINETIC_MODEL = os.environ.get("P_BRAIN_MODEL", "both")


### PR DESCRIPTION
## Summary
- use the real solver `two_compartment_tikhonov_fit` when computing ROI values
- keep vp and CBF for ROI reporting
- rename helper variables to remove the `tikhonov` label
- update output saving for the new model name
- document two-compartment model in README and settings
- fix output renaming from old `_tikhonov` suffix

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68694ed24e20832196a4a491f853a274