### PR TITLE
Add optional L-curve regularisation for two-compartment model

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,6 +44,8 @@ def parse_args():
     parser.add_argument('--lambda', dest='tikhonov_lambda', type=float,
                         help='Tikhonov regularisation weight for the two-compartment model',
                         required=False)
+    parser.add_argument('--enable-lcurve', action='store_true',
+                        help='Automatically pick Tikhonov \u03bb via L-curve')
     return parser.parse_args()
 
 
@@ -124,6 +126,8 @@ def main():
 
     if args.tikhonov_lambda is not None:
         settings.TIKHONOV_LAMBDA = args.tikhonov_lambda
+    if args.enable_lcurve:
+        settings.AUTO_LAMBDA = True
 
     # Respect ``PBRAIN_TURBO`` to disable plotting when running in batch mode.
     # Individual modes may override this later (manual/pseudo always show plots).

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -27,6 +27,7 @@ from .kinetic_models import (
     construct_convolution_matrix,
     tikhonov_regularization,
     extended_tofts_model,
+    pick_lambda_via_l_curve,
 )
 from skimage.transform import resize
 import json
@@ -49,6 +50,8 @@ def patlak_total(C_t, C_a, t):
 def two_compartment_tikhonov(aif, tissue_curve, *, time_array,
                              lambd=settings.TIKHONOV_LAMBDA):
     """Two-compartment fit using Tikhonov regularisation."""
+    if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+        lambd = settings.AUTO_LAMBDA_VALUE
     Ktrans, ve, vp = extended_tofts_tikhonov(aif, tissue_curve, time_array, lambd=lambd)
     Ki = Ktrans * 6000
     lam = ve * 100
@@ -1956,7 +1959,10 @@ def compute_and_plot_ctcs_median(
                 if compute_per_voxel_CBF:
                     delta_t = np.diff(time_points_voxel)[0]
                     A = construct_convolution_matrix(C_a_voxel, delta_t)
-                    lambd = settings.TIKHONOV_LAMBDA
+                    if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+                        lambd = settings.AUTO_LAMBDA_VALUE
+                    else:
+                        lambd = settings.TIKHONOV_LAMBDA
 
                     # Solve for the residue function
                     try:
@@ -2110,6 +2116,30 @@ def compute_and_plot_ctcs_median(
     C_t_gm_cerebellum_total  = avg_gm_cerebellum_ctc_total[:min_length]
     C_t_wm_cerebellum_total  = avg_wm_cerebellum_ctc_total[:min_length]
     C_t_wm_cc_total          = avg_wm_cc_ctc_total[:min_length]
+
+    if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is None:
+        global_ctcs = [
+            C_t_wm_total,
+            C_t_cortical_gm_total,
+            C_t_subcortical_gm_total,
+            C_t_gm_brainstem_total,
+            C_t_gm_cerebellum_total,
+            C_t_wm_cerebellum_total,
+            C_t_wm_cc_total,
+        ]
+        if boundary and C_t_boundary_total.size:
+            global_ctcs.append(C_t_boundary_total)
+        stacked = np.vstack([ct for ct in global_ctcs if ct.size])
+        median_ct = np.median(stacked, axis=0)
+        lambd = pick_lambda_via_l_curve(C_a_total, median_ct, time_points_total,
+                                        settings.AUTO_LAMBDA_CANDIDATES)
+        settings.AUTO_LAMBDA_VALUE = lambd
+        plot_l_curve(C_a_total, median_ct, time_points_total,
+                     settings.AUTO_LAMBDA_CANDIDATES)
+        save_dir = os.path.join(image_directory, 'AI', 'Tissue functions')
+        os.makedirs(save_dir, exist_ok=True)
+        plt.savefig(os.path.join(save_dir, 'lcurve_global.png'), dpi=300)
+        plt.close()
 
     # ----------------------------------------------------------------------------- 
     # 2) Helper: run mask_problematic on the *trimmed* curve, then Patlak

--- a/modules/kinetic_models.py
+++ b/modules/kinetic_models.py
@@ -34,6 +34,53 @@ def tikhonov_regularization(A, C_t, lambd):
     return np.linalg.solve(regularized, A.T @ C_t)
 
 
+def pick_lambda_via_l_curve(aif, tissue_curve, time_array, lambdas):
+    """Return the lambda corresponding to the L-curve corner."""
+    delta_t = np.diff(time_array).mean()
+    A = construct_convolution_matrix(aif, delta_t)
+    R, S = [], []
+    for lam in lambdas:
+        theta = tikhonov_regularization(A, tissue_curve, lam)
+        R.append(np.linalg.norm(A.dot(theta) - tissue_curve))
+        S.append(np.linalg.norm(theta))
+    logR, logS = np.log(R), np.log(S)
+    kappa = []
+    for i in range(1, len(lambdas) - 1):
+        x1, y1 = logR[i - 1], logS[i - 1]
+        x2, y2 = logR[i], logS[i]
+        x3, y3 = logR[i + 1], logS[i + 1]
+        num = abs((x2 - x1) * (y3 - y1) - (y2 - y1) * (x3 - x1))
+        den = (np.hypot(x2 - x1, y2 - y1) *
+               np.hypot(x3 - x2, y3 - y2) *
+               np.hypot(x3 - x1, y3 - y1))
+        kappa.append(num / den if den > 0 else 0)
+    idx = np.argmax(kappa) + 1
+    return lambdas[idx]
+
+
+def plot_l_curve(aif, tissue_curve, time_array, lambdas):
+    """Plot the L-curve and return the selected lambda."""
+    import matplotlib.pyplot as plt
+
+    delta_t = np.diff(time_array).mean()
+    A = construct_convolution_matrix(aif, delta_t)
+    R, S = [], []
+    for lam in lambdas:
+        theta = tikhonov_regularization(A, tissue_curve, lam)
+        R.append(np.linalg.norm(A.dot(theta) - tissue_curve))
+        S.append(np.linalg.norm(theta))
+
+    best = pick_lambda_via_l_curve(aif, tissue_curve, time_array, lambdas)
+    idx = int(np.where(lambdas == best)[0][0])
+
+    plt.loglog(R, S, marker='o')
+    plt.scatter(R[idx], S[idx], color='red')
+    plt.xlabel(r'$\|A\theta - C_t\|$')
+    plt.ylabel(r'$\|\theta\|$')
+    plt.title('L-curve')
+    return best
+
+
 def extended_tofts_tikhonov(Cp, Ct, t, lambd=settings.TIKHONOV_LAMBDA,
                             x0=(0.001, 0.2, 0.05)):
     def residual(theta):

--- a/modules/opt04_tissue_function.py
+++ b/modules/opt04_tissue_function.py
@@ -13,6 +13,7 @@ from termcolor import colored
 from utils.mapping import *
 import glob
 import shutil
+import utils.settings as settings
 
 turbo_mode = True  # When True, suppress interactive plotting
 

--- a/modules/opt05_BBB_parameters.py
+++ b/modules/opt05_BBB_parameters.py
@@ -7,6 +7,7 @@ from .kinetic_models import (
     construct_convolution_matrix,
     tikhonov_regularization,
     extended_tofts_model,
+    pick_lambda_via_l_curve,
 )
 import numpy as np
 from termcolor import colored
@@ -175,15 +176,23 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
     use_patlak = model in ('patlak', 'both')
 
     if use_two_compartment:
+        if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+            lambd = settings.AUTO_LAMBDA_VALUE
+        else:
+            lambd = settings.TIKHONOV_LAMBDA
         Ktrans, ve, vp = extended_tofts_tikhonov(C_a, C_t, time_points_s,
-                                                 lambd=settings.TIKHONOV_LAMBDA)
+                                                 lambd=lambd)
         Ki = Ktrans * 6000
         lamda = ve * 100
         SD_Ki = np.nan
         fit_curve = extended_tofts_model(time_points_s, Ktrans, ve, vp, C_a)
         delta_t = np.diff(time_points_s)[0]
         A = construct_convolution_matrix(C_a, delta_t)
-        residue = tikhonov_regularization(A, C_t, settings.TIKHONOV_LAMBDA)
+        if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+            cbf_lambda = settings.AUTO_LAMBDA_VALUE
+        else:
+            cbf_lambda = settings.TIKHONOV_LAMBDA
+        residue = tikhonov_regularization(A, C_t, cbf_lambda)
         CBF = residue[0] * 6000
         print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
               f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
@@ -198,8 +207,13 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s,
                                           subtype_tissue, image_directory)
         baseline_point = find_shifted_baseline(C_t)+1
-        P, P_std = compute_average_permeability(C_a, C_t, time_points_s,
-                                               baseline_point=baseline_point)
+        if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+            lam_fit = settings.AUTO_LAMBDA_VALUE
+        else:
+            lam_fit = settings.TIKHONOV_LAMBDA
+        P, P_std = compute_average_permeability(
+            C_a, C_t, time_points_s,
+            baseline_point=baseline_point, lambd=lam_fit)
         print('[!] Advanced computation of permeability: (', P, '+-', P_std,
               ') ml/100g/min')
         print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
@@ -230,15 +244,23 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         use_patlak = model in ('patlak', 'both')
 
         if use_two_compartment:
+            if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+                lambd = settings.AUTO_LAMBDA_VALUE
+            else:
+                lambd = settings.TIKHONOV_LAMBDA
             Ktrans, ve, vp = extended_tofts_tikhonov(
-                C_a, C_t, time_points_s, lambd=settings.TIKHONOV_LAMBDA)
+                C_a, C_t, time_points_s, lambd=lambd)
             Ki = Ktrans * 6000
             lamda = ve * 100
             SD_Ki = np.nan
             fit_curve = extended_tofts_model(time_points_s, Ktrans, ve, vp, C_a)
             delta_t = np.diff(time_points_s)[0]
             A = construct_convolution_matrix(C_a, delta_t)
-            residue = tikhonov_regularization(A, C_t, settings.TIKHONOV_LAMBDA)
+            if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+                cbf_lambda = settings.AUTO_LAMBDA_VALUE
+            else:
+                cbf_lambda = settings.TIKHONOV_LAMBDA
+            residue = tikhonov_regularization(A, C_t, cbf_lambda)
             CBF = residue[0] * 6000
             print(f'[!] Two-compartment Ki: {Ki:.5f} ml/100g/min, '
                   f'lambda: {lamda:.5f} ml/100g, vp: {vp:.5f}, CBF: {CBF:.5f}')
@@ -252,7 +274,13 @@ def BBB_parameters(analysis_directory, image_directory):  # Ki from ROI
         if use_patlak:
             Ki, lamda, SD_Ki = patlak_analysis(C_t, C_a, time_points_s, subtype_tissue, image_directory)
             baseline_point = find_shifted_baseline(C_t)+1
-            P, P_std = compute_average_permeability(C_a, C_t, time_points_s, baseline_point=baseline_point)
+            if settings.AUTO_LAMBDA and settings.AUTO_LAMBDA_VALUE is not None:
+                lam_fit = settings.AUTO_LAMBDA_VALUE
+            else:
+                lam_fit = settings.TIKHONOV_LAMBDA
+            P, P_std = compute_average_permeability(
+                C_a, C_t, time_points_s,
+                baseline_point=baseline_point, lambd=lam_fit)
             print('[!] Advanced computation of permeability: (', P, '+-', P_std, ') ml/100g/min')
             print(f'[!] Ki: {Ki*6000} ml/100g min, lambda: {lamda*100} ml/100g, SD_Ki: {SD_Ki*6000}')
             save_values(Ki, SD_Ki, lamda, P, P_std, subtype_tissue, slice_tissue,

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import numpy as np
 import matplotlib
 matplotlib.use("TkAgg")
 
@@ -22,7 +23,14 @@ NUMBER_OF_CORES = int(os.environ.get("P_BRAIN_CORES", 4))
 KINETIC_MODEL = os.environ.get("P_BRAIN_MODEL", "both")
 
 # Regularisation strength for the two-compartment model
-TIKHONOV_LAMBDA = float(os.environ.get("P_BRAIN_LAMBDA", 5.0))
+TIKHONOV_LAMBDA = float(os.environ.get("P_BRAIN_LAMBDA", 0.5))
+
+# When enabled, pick the regularisation weight automatically using an L-curve
+# search across ``AUTO_LAMBDA_CANDIDATES``.
+AUTO_LAMBDA = False
+AUTO_LAMBDA_CANDIDATES = np.logspace(-2, 2, 30)
+# Holds the most recently chosen value when ``AUTO_LAMBDA`` is True
+AUTO_LAMBDA_VALUE = None
 
 # Paths to the neural network models used for artery and vein ROI extraction.
 # These can be overridden by environment variables to use custom models.
@@ -153,6 +161,8 @@ def save_run_settings(analysis_directory, parameters):
         "CONTROLS": CONTROLS,
         "TIKHONOV_LAMBDA": TIKHONOV_LAMBDA,
     })
+    if AUTO_LAMBDA:
+        settings["AUTO_LAMBDA_VALUE"] = AUTO_LAMBDA_VALUE
     settings_path = os.path.join(analysis_directory, "run_settings.json")
     with open(settings_path, "w") as f:
         json.dump(settings, f, indent=4)


### PR DESCRIPTION
## Summary
- default Tikhonov λ is 0.5 with optional automatic selection
- add `--enable-lcurve` flag and setting to compute a global λ via L-curve
- compute λ from the whole-brain median tissue curve and save `lcurve_global.png`
- store the chosen value in run settings and reuse it for all fits
- fix NameError in `opt04_tissue_function`

## Testing
- `pip install numpy scipy matplotlib termcolor pyfiglet seaborn nibabel tqdm dipy opencv-python scikit-image tensorflow`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68698bc586348321acc66fed0a09ae26