### PR TITLE
Preserve ROI screenshot across kinetic model runs

### DIFF
--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -2585,9 +2585,26 @@ def tissue_function_AI(analysis_directory, nifti_directory, image_directory, fil
     model_setting = settings.KINETIC_MODEL.lower()
     models = ['patlak', 'two_compartment'] if model_setting == 'both' else [model_setting]
     ai_base = os.path.join(image_directory, 'AI')
+
+    screenshot_name = 'AI_input_function_ROIs.png'
+    screenshot_backup = os.path.join(image_directory, screenshot_name)
+
+    # Preserve screenshot generated during ROI extraction
+    screenshot_src = os.path.join(ai_base, screenshot_name)
+    if os.path.exists(screenshot_src):
+        shutil.copy2(screenshot_src, screenshot_backup)
+
     for m in models:
         print(f'[!] Running {m} model')
         if os.path.exists(ai_base):
             shutil.rmtree(ai_base)
         os.makedirs(ai_base, exist_ok=True)
+
+        # Copy screenshot into the freshly created AI directory if available
+        if os.path.exists(screenshot_backup):
+            shutil.copy2(screenshot_backup, os.path.join(ai_base, screenshot_name))
+
         _tissue_function_AI(m, analysis_directory, nifti_directory, image_directory, filenames, parameters)
+
+    if os.path.exists(screenshot_backup):
+        os.remove(screenshot_backup)


### PR DESCRIPTION
## Summary
- ensure `AI_input_function_ROIs.png` survives Patlak/2-compartment runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68750b7b0440832194b44c466b1000f2