### PR TITLE
Allow custom data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ _p_-Brain is a Python toolkit for quantitative analysis of MRI data with a focus
 All core functionality resides in the `modules/` package while helper routines are located under `utils/`. Optional neural networks for artery and vein identification are stored in the `AI/` directory. A small GUI is used to select a dataset, after which a terminal menu guides the user through each processing step. For cohort processing the script `enumerator.py` can launch `main.py` for multiple subjects in sequence, enabling unattended analysis.
 
 ## 2. Directory & Data Structure
-The software expects a specific directory structure for optimal functioning. The MRI data to be analysed upon should be placed within the Data folder as follows:
+The software expects a specific directory structure for optimal functioning. By default the MRI data should be placed within the `Data` folder, though an alternative location can be supplied via the `--data-dir` command line option or by setting the `P_BRAIN_DATA_DIR` environment variable. The layout inside the chosen directory must follow this structure:
 
 ```
 data
@@ -44,7 +44,7 @@ data
 └── data_2
 ...
 ```
-Place your .PAR/.REC MRI data in the `data` directory under any folder name of your choosing. p-Brain will create the required subdirectories (e.g. `Analysis`, `Images`, `NIfTI`) automatically. NIfTI files generated from PAR/REC input or provided directly are stored under `NIfTI`, while derived figures are written to the `Images` directory.
+Place your .PAR/.REC MRI data in the `data` directory (or the directory passed via `--data-dir`) under any folder name of your choosing. p-Brain will create the required subdirectories (e.g. `Analysis`, `Images`, `NIfTI`) automatically. NIfTI files generated from PAR/REC input or provided directly are stored under `NIfTI`, while derived figures are written to the `Images` directory.
 
 ### Repository overview
 - **modules/** – menu implementations such as T1 fitting and permeability models.
@@ -74,6 +74,10 @@ python enumerator.py --all
 python enumerator.py --controls 01 02
 python enumerator.py --controls --all
 ```
+
+Both `main.py` and `enumerator.py` accept the `--data-dir` flag to point to an
+alternative dataset directory. Setting the `P_BRAIN_DATA_DIR` environment
+variable achieves the same effect.
 
 NIfTI files can also be used directly by simply creating a folder of the same name and placing the .nii files therein. This will avoid the automatic conversion from .PAR/.REC to .nii/.json. 
 

--- a/enumerator.py
+++ b/enumerator.py
@@ -1,22 +1,28 @@
-import sys
+import argparse
 import subprocess
 import os
+import sys
 
-# Path to the directory containing the datasets
-data_directory = os.path.join(os.path.dirname(os.path.abspath(__file__)), "data")
 
-# Get arguments from the command line
-args = sys.argv[1:]
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run p-brain on multiple datasets")
+    parser.add_argument('--data-dir', dest='data_dir', type=str,
+                        default=os.environ.get(
+                            'P_BRAIN_DATA_DIR',
+                            os.path.join(os.path.dirname(os.path.abspath(__file__)), 'data')
+                        ),
+                        help='Directory containing dataset folders')
+    parser.add_argument('--controls', action='store_true', help='Process control datasets')
+    parser.add_argument('--all', action='store_true', help='Process all datasets in the data directory')
+    parser.add_argument('ids', nargs='*', help='Specific dataset IDs to process')
+    return parser.parse_args()
 
-# Normalise arguments for easy checks
-args_lower = [arg.lower() for arg in args]
 
-# Flags
-use_controls = "--controls" in args_lower
-use_all = "--all" in args_lower
-
-# Collect numeric dataset IDs in the order provided
-ids = [arg for arg in args if not arg.startswith("--")]
+args = parse_args()
+data_directory = os.path.abspath(args.data_dir)
+use_controls = args.controls
+use_all = args.all
+ids = args.ids
 
 # Determine which datasets to process and whether they are controls
 datasets = []  # list of tuples (id, is_control)
@@ -63,6 +69,7 @@ command_template = "python3 main.py --id {} --mode auto"
 for id, is_control in datasets:
     command = command_template.format(id)
     env = os.environ.copy()
+    env["P_BRAIN_DATA_DIR"] = data_directory
     if is_control:
         env["PBRAIN_CONTROLS"] = "true"
     else:

--- a/main.py
+++ b/main.py
@@ -35,9 +35,9 @@ def mode_choice():
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description = "Run the neuroimagining analysis tool")
-    parser.add_argument('--id', type=str, help = 'Patient ID, corresponding to folder names in data/', required = False)
-    parser.add_argument('--option', type=int, help = 'Analysis option (welcome screen)', required = False)
+    parser = argparse.ArgumentParser(description="Run the neuroimagining analysis tool")
+    parser.add_argument('--id', type=str, help='Patient ID, corresponding to folder names in data/', required=False)
+    parser.add_argument('--option', type=int, help='Analysis option (welcome screen)', required=False)
     # Optional mode argument to skip the interactive mode selection
     parser.add_argument('--mode', type=str, choices=['manual', 'auto', 'pseudo'],
                         help='Start directly in a specific analysis mode', required=False)
@@ -46,6 +46,9 @@ def parse_args():
                         required=False)
     parser.add_argument('--enable-lcurve', action='store_true',
                         help='Automatically pick Tikhonov \u03bb via L-curve')
+    parser.add_argument('--data-dir', dest='data_dir', type=str,
+                        default=os.environ.get('P_BRAIN_DATA_DIR'),
+                        help='Directory containing subject folders (default: ./Data)')
     return parser.parse_args()
 
 
@@ -141,12 +144,13 @@ def main():
     turbo_env = os.environ.get("PBRAIN_TURBO") == "1"
     set_turbo_mode(turbo_env)
 
+    data_root = args.data_dir
     if args.id:
         log_number = args.id
     else:
-        log_number = select_log_number()
-    
-    data_directory, analysis_directory, nifti_directory, image_directory = setup_directories(log_number)
+        log_number = select_log_number(data_root)
+
+    data_directory, analysis_directory, nifti_directory, image_directory = setup_directories(log_number, data_root)
     if CONTROLS:
         filenames = control_filenames(nifti_directory)
     else:

--- a/modules/start.py
+++ b/modules/start.py
@@ -31,10 +31,22 @@ def print_banner():
 
 availability_toggled = False
 
-def select_log_number():
-    """GUI for selecting a dataset."""
+
+def select_log_number(data_root=None):
+    """GUI for selecting a dataset.
+
+    ``data_root`` specifies the directory containing subject folders. When not
+    provided, the ``P_BRAIN_DATA_DIR`` environment variable is honoured before
+    falling back to a local ``Data`` directory.
+    """
 
     global selected_log_number
+
+    if data_root is None:
+        data_root = os.environ.get("P_BRAIN_DATA_DIR")
+        if data_root is None:
+            data_root = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 'Data')
+    data_root = os.path.abspath(data_root)
 
     root = tk.Tk()
     root.title('Select Log Number')
@@ -43,7 +55,6 @@ def select_log_number():
     frame = tk.Frame(root)
     frame.pack(side=tk.TOP, fill=tk.BOTH, expand=tk.YES)
 
-    data_root = os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), 'Data')
     current_path = data_root
     log_numbers = []
 

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -49,17 +49,34 @@ AI_MODEL_PATHS = {
     ),
 }
 
+
+def _default_data_root():
+    """Return the default root directory for datasets.
+
+    Prefers the ``P_BRAIN_DATA_DIR`` environment variable and falls back to a
+    ``Data`` folder next to the executable.
+    """
+
+    env_root = os.environ.get("P_BRAIN_DATA_DIR")
+    if env_root:
+        return os.path.abspath(env_root)
+    return os.path.join(os.path.dirname(os.path.abspath(sys.argv[0])), "Data")
+
 def create_directory(path):
     if not os.path.exists(path):
         os.makedirs(path)
 
-def setup_directories(log_number):
-    base_path = os.path.dirname(os.path.abspath(sys.argv[0]))
-    data_directory = os.path.join(base_path, 'Data', log_number)
+def setup_directories(log_number, data_root=None):
+    if data_root is None:
+        data_root = _default_data_root()
+    else:
+        data_root = os.path.abspath(data_root)
+
+    data_directory = os.path.join(data_root, log_number)
 
     # Look for control data if enabled
     if CONTROLS:
-        control_directory = os.path.join(base_path, 'Data', 'controls', log_number)
+        control_directory = os.path.join(data_root, 'controls', log_number)
         if os.path.isdir(control_directory):
             data_directory = control_directory
             flag_path = os.path.join(control_directory, CONTROL_FLAG_FILENAME)


### PR DESCRIPTION
## Summary
- add `--data-dir` option and `P_BRAIN_DATA_DIR` env var to set dataset location
- update directory setup and selection GUI to honor custom data root
- document custom data directory support

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad88bba35c83218456b3ae32008b7b