### PR TITLE
Allow excluding edge slices from global Ki

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,8 +273,15 @@ The Tikhonov parameter controlling the two-compartment fit is configured via
 `--lambda` on the command line or the `P_BRAIN_LAMBDA` environment variable.
 The default value is 5.0 and can also be changed in `utils/settings.py`.
 
+### Global Ki slice exclusion
+The computation of global Ki for white matter, cortical grey matter and the
+boundary region ignores the first and last two slices of the volume by default.
+Adjust the number of excluded slices with the environment variables
+`P_BRAIN_GLOBAL_KI_SKIP_BOTTOM` and `P_BRAIN_GLOBAL_KI_SKIP_TOP` or modify the
+corresponding values in `utils/settings.py`.
+
 ## 7. Contributions
-For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue. 
+For contributions, feature requests, and bug reporting, please contact me (Edis Tireli) through here, or add an issue.
 
 ## 8. License
 This project is licensed under the MIT License. For full license information, please refer to the LICENSE.md file in the repository.

--- a/modules/AI_tissue_functions.py
+++ b/modules/AI_tissue_functions.py
@@ -1531,6 +1531,8 @@ def compute_and_plot_ctcs_median(
     from scipy.ndimage import binary_dilation
 
     n_slices = t2_img.shape[2]
+    skip_bottom = settings.GLOBAL_KI_SKIP_BOTTOM
+    skip_top = settings.GLOBAL_KI_SKIP_TOP
 
     # Load C_a once
     max_folder = os.path.join(analysis_directory, 'TSCC Data', 'Max')
@@ -1687,16 +1689,25 @@ def compute_and_plot_ctcs_median(
         if boundary and len(boundary_indices) > 0:
             boundary_ctcs = process_ctcs(boundary_indices)
 
-        # Add the valid CTCs from this slice to the total lists
-        wm_ctcs_total.extend(wm_ctcs)
-        cortical_gm_ctcs_total.extend(cortical_gm_ctcs)
+        # Add the valid CTCs from this slice to the total lists used for
+        # global Ki calculations.  White matter, cortical grey matter and
+        # boundary contributions can optionally exclude slices from the
+        # inferior and superior ends of the volume.
+        include_global = (i >= skip_bottom) and (i < n_slices - skip_top)
+        if include_global:
+            wm_ctcs_total.extend(wm_ctcs)
+            cortical_gm_ctcs_total.extend(cortical_gm_ctcs)
+            if boundary and boundary_ctcs:
+                boundary_ctcs_total.extend(boundary_ctcs)
+        else:
+            # Even if excluded from global totals we still compute per-slice
+            # and per-voxel values.
+            pass
         subcortical_gm_ctcs_total.extend(subcortical_gm_ctcs)
         gm_brainstem_ctcs_total.extend(gm_brainstem_ctcs)
         gm_cerebellum_ctcs_total.extend(gm_cerebellum_ctcs)
         wm_cerebellum_ctcs_total.extend(wm_cerebellum_ctcs)
         wm_cc_ctcs_total.extend(wm_cc_ctcs)
-        if boundary and boundary_ctcs:
-            boundary_ctcs_total.extend(boundary_ctcs)
 
         # Compute median CTCs if valid CTCs are available
         avg_wm_ctc = np.median(wm_ctcs, axis=0) if wm_ctcs else np.array([])

--- a/utils/settings.py
+++ b/utils/settings.py
@@ -32,6 +32,14 @@ AUTO_LAMBDA_CANDIDATES = np.logspace(-2, 2, 30)
 # Holds the most recently chosen value when ``AUTO_LAMBDA`` is True
 AUTO_LAMBDA_VALUE = None
 
+# Number of slices to omit from the inferior (bottom) and superior (top)
+# ends when computing global Ki for white matter, cortical grey matter
+# and boundary tissues.  These can be overridden via the environment
+# variables ``P_BRAIN_GLOBAL_KI_SKIP_BOTTOM`` and
+# ``P_BRAIN_GLOBAL_KI_SKIP_TOP``.
+GLOBAL_KI_SKIP_BOTTOM = int(os.environ.get("P_BRAIN_GLOBAL_KI_SKIP_BOTTOM", 2))
+GLOBAL_KI_SKIP_TOP = int(os.environ.get("P_BRAIN_GLOBAL_KI_SKIP_TOP", 2))
+
 # Paths to the neural network models used for artery and vein ROI extraction.
 # These can be overridden by environment variables to use custom models.
 AI_MODEL_PATHS = {
@@ -177,6 +185,8 @@ def save_run_settings(analysis_directory, parameters):
         "AI_MODEL_PATHS": AI_MODEL_PATHS,
         "CONTROLS": CONTROLS,
         "TIKHONOV_LAMBDA": TIKHONOV_LAMBDA,
+        "GLOBAL_KI_SKIP_BOTTOM": GLOBAL_KI_SKIP_BOTTOM,
+        "GLOBAL_KI_SKIP_TOP": GLOBAL_KI_SKIP_TOP,
     })
     if AUTO_LAMBDA:
         settings["AUTO_LAMBDA_VALUE"] = AUTO_LAMBDA_VALUE


### PR DESCRIPTION
## Summary
- Add settings to skip bottom and top slices when computing global Ki for white matter, cortical grey matter and boundary tissues
- Honour these settings in global Ki aggregation logic
- Document new environment variables for slice exclusion in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed30556b88321abf81246826933d5