### PR TITLE
Fix lambda scaling in Tikhonov deconvolution

### DIFF
--- a/modules/kinetic_models.py
+++ b/modules/kinetic_models.py
@@ -74,8 +74,8 @@ def tikhonov_regularization(A, C_t, lambd, *, penalty="identity"):
     L = _prepare_penalty_matrix(n_cols, penalty)
     ata = A.T @ A
     ltl = L.T @ L if L.size else np.zeros((n_cols, n_cols), dtype=float)
-    lam_sq = float(max(lambd, 0.0)) ** 2
-    regularised = ata + lam_sq * ltl
+    lam = float(max(lambd, 0.0))
+    regularised = ata + lam * ltl
     rhs = A.T @ C_t
     return np.linalg.solve(regularised, rhs)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,7 @@ sys.modules['modules.AI_tissue_functions'] = ai
 spec_ai.loader.exec_module(ai)
 patlak_total = ai.patlak_total
 two_compartment = ai.two_compartment_tikhonov
+settings_module = ai.settings
 
 
 def synthetic_data():
@@ -115,12 +116,12 @@ def test_two_compartment_uses_patlak_initial_guess():
     assert np.isclose(captured['x0'][0], ki_patlak / 6000.0, rtol=0.05)
 
 
-def test_tikhonov_uses_lambda_squared():
+def test_tikhonov_regularisation_uses_linear_lambda():
     a = np.eye(4)
     ct = np.arange(1, 5, dtype=float)
     lam = 2.0
     sol = km.tikhonov_regularization(a, ct, lam)
-    expected = ct / (1.0 + lam ** 2)
+    expected = ct / (1.0 + lam)
     assert np.allclose(sol, expected)
 
 


### PR DESCRIPTION
## Summary
- restore the original regularisation strength definition by removing the unintended squaring of the Tikhonov lambda
- update the associated unit test to reflect the linear lambda scaling and expose settings for reuse

## Testing
- pytest tests/test_models.py

------
https://chatgpt.com/codex/tasks/task_e_68f68c06c3cc8321b89323ff48a19721